### PR TITLE
Fix macOS build & make VST3 loadable in Live 12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ include(cmake/setup_tests_and_benchmarks.cmake)
 # JUCE compile definitions and linking
 include(cmake/juce_compile_config.cmake)
 
+# Ad-hoc sign plugin bundles after build (macOS dev convenience)
+include(cmake/sign_plugin.cmake)
+
 # Add Installer and RNBO
 add_subdirectory(installer)
 add_subdirectory(modules/RnboExport)

--- a/cmake/setup_libsamplerate.cmake
+++ b/cmake/setup_libsamplerate.cmake
@@ -1,5 +1,7 @@
 set(LIBSAMPLERATE_TESTS OFF CACHE BOOL "Disable deprecated LIBSAMPLERATE_TESTS option" FORCE)
 
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/modules/libsamplerate)
 
 target_link_libraries(${TARGET_NAME} PRIVATE samplerate)

--- a/cmake/sign_plugin.cmake
+++ b/cmake/sign_plugin.cmake
@@ -1,0 +1,21 @@
+# Ad-hoc code-signing of plugin bundles on macOS.
+#
+# Apple's linker auto-stamps binaries with a minimal ad-hoc signature, but it
+# does not seal the bundle's resources or bind Info.plist. Strict hosts (e.g.
+# Ableton Live 12's VST3 scanner) reject bundles in that state.
+# Re-signing the whole bundle with `codesign --sign -` produces a proper
+# resource seal so those hosts accept the plugin. The release pipeline overrides this with 
+# a real Developer ID signature afterwards.
+
+if(APPLE)
+    foreach(fmt IN ITEMS VST3 AU Standalone)
+        set(_tgt ${TARGET_NAME}_${fmt})
+        if(TARGET ${_tgt})
+            add_custom_command(TARGET ${_tgt} POST_BUILD
+                COMMAND codesign --force --deep --sign - --timestamp=none
+                        "$<TARGET_BUNDLE_DIR:${_tgt}>"
+                COMMENT "Ad-hoc signing ${_tgt} bundle"
+                VERBATIM)
+        endif()
+    endforeach()
+endif()

--- a/modules/RnboExport/CMakeLists.txt
+++ b/modules/RnboExport/CMakeLists.txt
@@ -3,6 +3,12 @@ add_library(rnbo_gran_delay STATIC
 		${CMAKE_CURRENT_SOURCE_DIR}/rnbo_granular.cpp
 )
 
+set_target_properties(rnbo_gran_delay PROPERTIES
+        CXX_STANDARD 17
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)
+
 target_include_directories(rnbo_gran_delay PRIVATE
 		${CMAKE_CURRENT_SOURCE_DIR}/rnbo
 		${CMAKE_CURRENT_SOURCE_DIR}/rnbo/common


### PR DESCRIPTION
**Fix macOS build & make VST3 loadable in Live 12**:

- Pin `CMAKE_POLICY_VERSION_MINIMUM 3.5` in `setup_libsamplerate.cmake` so the bundled libsamplerate (which declares `cmake_minimum_required(3.1..3.18))` configures with CMake ≥ 4.0.
- Set `CXX_STANDARD 17` on the `rnbo_gran_delay` target in `CMakeLists.txt`; without it AppleClang falls back to gnu++98 and rejects RNBO's constexpr / alias declarations.
- Add `sign_plugin.cmake` (`POST_BUILD codesign --force --deep --sign -`) so the bundle's `Info.plist` is bound and `CodeResources` sealed; otherwise Live 12's VST3 scanner rejects the plugin (Reaper and AU hosts don't, which is why only the VST3 was silently skipped). The CI Developer ID signing step overwrites this in release builds.