### PR TITLE
Improve model loading, unblock CI, and stamp builds with git commit info

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,6 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
+
+[*.{bat,cmd,ps1}]
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto eol=lf
+
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf

--- a/.github/workflows/build_test_artifacts.yml
+++ b/.github/workflows/build_test_artifacts.yml
@@ -54,7 +54,7 @@ jobs:
       # The uses keyword retrieves the action from the actions/checkout repository
       # With this we checkout to our repo
       - name: get repo and submodules
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       # Here we get the submodules like juce
         with:
           submodules: true
@@ -181,7 +181,7 @@ jobs:
       #    zip -vr ${{ env.PRODUCT_NAME }}.zip ${{ env.PRODUCT_NAME }}/ -x "*.DS_Store"
       
       - name: upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.PRODUCT_NAME }}.zip
           path: packaging/${{ env.PRODUCT_NAME }}.zip

--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,27 @@
-cmake-build*
-CMakeFiles/*
+# Dependencies
 modules/RnboExport/
 modules/onnxruntime/
 modules/onnxruntime-1.14.1-win-x86_64_Debug
-Builds
-BinaryData.h
-BinaryData*.cpp
+
+# Build
+cmake-build*
+CMakeFiles/*
 build*/
+Builds
 Bin*/
 JuceLibraryCode
 LV2.mak
-.idea
-.DS_Store
-.vscode/
+BinaryData.h
+BinaryData*.cpp
+
+# IDE
 .idea/
+.vscode/*
+!.vscode/settings.json
+.cursor/
+
+# OS
+.DS_Store
+
+# Platform
 Plugin/xcode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "files.eol": "\n",
+  "files.insertFinalNewline": true
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ include(cmake/configure_platform.cmake)
 add_subdirectory(modules/JUCE)
 # JUCE plugin setup
 include(cmake/juce_plugin_setup.cmake)
+include(cmake/generate_build_info.cmake)
 
 
 # ONNX Runtime and libsamplerate

--- a/cmake/BuildInfo.h.in
+++ b/cmake/BuildInfo.h.in
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace BuildInfo
+{
+    inline constexpr const char* commitHash = "@GIT_COMMIT_HASH@";
+    inline constexpr const char* commitDate = "@GIT_COMMIT_DATE_FORMATTED@";
+}

--- a/cmake/generate_build_info.cmake
+++ b/cmake/generate_build_info.cmake
@@ -1,0 +1,18 @@
+set(BUILD_INFO_HEADER "${CMAKE_BINARY_DIR}/generated/BuildInfo.h")
+
+file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/generated")
+
+add_custom_command(
+    OUTPUT "${BUILD_INFO_HEADER}"
+    COMMAND ${CMAKE_COMMAND}
+        -DSOURCE_DIR=${CMAKE_SOURCE_DIR}
+        -DOUTPUT_FILE=${BUILD_INFO_HEADER}
+        -P ${CMAKE_SOURCE_DIR}/cmake/write_build_info.cmake
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    COMMENT "Generating build info"
+)
+
+add_custom_target(GenerateBuildInfo DEPENDS "${BUILD_INFO_HEADER}")
+add_dependencies(${TARGET_NAME} GenerateBuildInfo)
+
+target_include_directories(${TARGET_NAME} PRIVATE "${CMAKE_BINARY_DIR}/generated")

--- a/cmake/write_build_info.cmake
+++ b/cmake/write_build_info.cmake
@@ -1,0 +1,42 @@
+if(NOT DEFINED SOURCE_DIR)
+    message(FATAL_ERROR "SOURCE_DIR is not set")
+endif()
+
+if(NOT DEFINED OUTPUT_FILE)
+    message(FATAL_ERROR "OUTPUT_FILE is not set")
+endif()
+
+set(GIT_COMMIT_HASH "unknown")
+set(GIT_COMMIT_DATE_FORMATTED "unknown")
+
+find_program(GIT_EXECUTABLE git)
+
+if(GIT_EXECUTABLE)
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+        WORKING_DIRECTORY ${SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_COMMIT_HASH
+        ERROR_QUIET
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} log -1 --format=%ci
+        WORKING_DIRECTORY ${SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_COMMIT_DATE
+        ERROR_QUIET
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    string(LENGTH "${GIT_COMMIT_DATE}" GIT_COMMIT_DATE_LENGTH)
+    if(GIT_COMMIT_DATE_LENGTH GREATER 9)
+        string(SUBSTRING "${GIT_COMMIT_DATE}" 0 10 GIT_COMMIT_DATE_DAY)
+        set(GIT_COMMIT_DATE_FORMATTED "${GIT_COMMIT_DATE_DAY}")
+    endif()
+endif()
+
+configure_file(
+    ${SOURCE_DIR}/cmake/BuildInfo.h.in
+    ${OUTPUT_FILE}
+    @ONLY
+)

--- a/githooks/install.ps1
+++ b/githooks/install.ps1
@@ -1,0 +1,5 @@
+# Point this repository at the version-controlled hooks in githooks/.
+$ErrorActionPreference = "Stop"
+Set-Location (git rev-parse --show-toplevel)
+git config core.hooksPath githooks
+Write-Host "Installed git hooks from: $(Get-Location)\githooks"

--- a/githooks/install.sh
+++ b/githooks/install.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Point this repository at the version-controlled hooks in githooks/.
+set -e
+cd "$(git rev-parse --show-toplevel)"
+git config core.hooksPath githooks
+echo "Installed git hooks from: $(pwd)/githooks"

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Normalize line endings on staged files using .gitattributes rules.
+# LF for most text files; CRLF for *.bat, *.cmd, and *.ps1.
+#
+# Install once from the repo root:
+#   git config core.hooksPath githooks
+# or run:  ./githooks/install.sh   (Git Bash / macOS / Linux)
+#         ./githooks/install.ps1  (PowerShell)
+
+set -e
+
+git diff --cached --name-only -z --diff-filter=ACM | while IFS= read -r -d '' file; do
+  git add --renormalize -- "$file"
+  git restore --worktree -- "$file"
+done
+
+exit 0

--- a/source/PluginEditor.cpp
+++ b/source/PluginEditor.cpp
@@ -3,19 +3,20 @@
 #include "PluginParameters.h"
 
 //==============================================================================
-AudioPluginAudioProcessorEditor::AudioPluginAudioProcessorEditor (AudioPluginAudioProcessor& p, juce::AudioProcessorValueTreeState& parameters)
-    : AudioProcessorEditor (&p), apvts(parameters), processorRef (p), fileChooserManager(p), transientViewer(p)/*, openGLBackground(parameters, p)*/, advancedParameterControl(parameters), parameterControl(parameters),
+AudioPluginAudioProcessorEditor::AudioPluginAudioProcessorEditor(AudioPluginAudioProcessor &p, juce::AudioProcessorValueTreeState &parameters)
+    : AudioProcessorEditor(&p), apvts(parameters), processorRef(p), fileChooserManager(p), transientViewer(p) /*, openGLBackground(parameters, p)*/, advancedParameterControl(parameters), parameterControl(parameters),
       footerComponent(p, parameters), headerComponent(p, parameters)
 {
-    juce::ignoreUnused (processorRef);
+    juce::ignoreUnused(processorRef);
 
     openGLBackground = std::make_unique<OpenGLBackground>(parameters, p);
 
-    for (auto & parameterID : PluginParameters::getPluginParameterList()) {
+    for (auto &parameterID : PluginParameters::getPluginParameterList())
+    {
         parameters.addParameterListener(parameterID, this);
     }
 
-    juce::LookAndFeel::setDefaultLookAndFeel (&customFontLookAndFeel);
+    juce::LookAndFeel::setDefaultLookAndFeel(&customFontLookAndFeel);
 
     headerComponent.onParameterControlViewChange = [this](bool newState)
     {
@@ -53,9 +54,10 @@ AudioPluginAudioProcessorEditor::AudioPluginAudioProcessorEditor (AudioPluginAud
 
     // Make sure that before the constructor has finished, you've set the
     // editor's size to whatever you need it to be.
-    setSize (1400, 700);
+    setSize(1400, 700);
 
-    processorRef.setExternalModelName = [this] (int modelID, juce::String& modelName) {
+    processorRef.setExternalModelName = [this](int modelID, juce::String &modelName)
+    {
         openGLBackground->externalModelLoaded(modelID, modelName);
     };
 
@@ -63,7 +65,7 @@ AudioPluginAudioProcessorEditor::AudioPluginAudioProcessorEditor (AudioPluginAud
     // dirty work around to make the blobs appear correctly from the beginning
     auto fadeParam = parameters.getParameter(PluginParameters::FADE_ID.getParamID());
     auto fadeStatus = fadeParam->getValue();
-    fadeParam->setValueNotifyingHost(0.5f*fadeStatus);
+    fadeParam->setValueNotifyingHost(0.5f * fadeStatus);
     fadeParam->setValueNotifyingHost(fadeStatus);
 
     xyPadComponents = openGLBackground->getXYPad()->getTooltipPointers();
@@ -75,31 +77,37 @@ AudioPluginAudioProcessorEditor::AudioPluginAudioProcessorEditor (AudioPluginAud
     addMouseListener(this, true);
 
     headerComponent.onScyloneButtonClick = [this](bool newState)
+    {
+        if (newState)
+        {
+            componentAnimator->fadeOut(&transientViewer, fadeTime);
+            if (headerComponent.detailButton.getToggleState())
             {
-                if (newState) {
-                    componentAnimator->fadeOut(&transientViewer, fadeTime);
-                    if (headerComponent.detailButton.getToggleState()) {
-                        componentAnimator->fadeOut(&advancedParameterControl, fadeTime);
-                    }
-                    else {
-                        componentAnimator->fadeOut(&parameterControl, fadeTime);
-                    }
-                }
-                else {
-                    if (headerComponent.detailButton.getToggleState()) {
-                        componentAnimator->fadeIn(&advancedParameterControl, fadeTime);
-                    }
-                    else {
-                        componentAnimator->fadeIn(&parameterControl, fadeTime);
-                        componentAnimator->fadeIn(&transientViewer, fadeTime);
-                    }
-                }
+                componentAnimator->fadeOut(&advancedParameterControl, fadeTime);
+            }
+            else
+            {
+                componentAnimator->fadeOut(&parameterControl, fadeTime);
+            }
+        }
+        else
+        {
+            if (headerComponent.detailButton.getToggleState())
+            {
+                componentAnimator->fadeIn(&advancedParameterControl, fadeTime);
+            }
+            else
+            {
+                componentAnimator->fadeIn(&parameterControl, fadeTime);
+                componentAnimator->fadeIn(&transientViewer, fadeTime);
+            }
+        }
 
-                openGLBackground->showSignalFlowChart(newState);
-                resized();
+        openGLBackground->showSignalFlowChart(newState);
+        resized();
 
-                headerComponent.detailButton.setEnabled(!newState);
-            };
+        headerComponent.detailButton.setEnabled(!newState);
+    };
 
     componentAnimator = std::make_unique<juce::ComponentAnimator>();
     initializeTooltipMap();
@@ -107,14 +115,15 @@ AudioPluginAudioProcessorEditor::AudioPluginAudioProcessorEditor (AudioPluginAud
 
 AudioPluginAudioProcessorEditor::~AudioPluginAudioProcessorEditor()
 {
-    juce::LookAndFeel::setDefaultLookAndFeel (nullptr);
-    for (auto & parameterID : PluginParameters::getPluginParameterList()) {
+    juce::LookAndFeel::setDefaultLookAndFeel(nullptr);
+    for (auto &parameterID : PluginParameters::getPluginParameterList())
+    {
         apvts.removeParameterListener(parameterID, this);
     }
 }
 
 //==============================================================================
-void AudioPluginAudioProcessorEditor::paint (juce::Graphics& g)
+void AudioPluginAudioProcessorEditor::paint(juce::Graphics &g)
 {
     // (Our component is opaque, so we must completely fill the background with a solid colour)
     g.fillAll(juce::Colour::fromString(ColorPallete::BG));
@@ -125,7 +134,7 @@ void AudioPluginAudioProcessorEditor::resized()
     auto r = getLocalBounds();
     r.removeFromTop(20);
 
-    auto logoSection = juce::Rectangle<int>{getWidth()/2 - 20, 20, 40, 20};
+    auto logoSection = juce::Rectangle<int>{getWidth() / 2 - 20, 20, 40, 20};
     auto headerSection = r.removeFromTop(32);
     auto padSection = r.removeFromLeft(700);
     padSection.removeFromBottom(35);
@@ -135,7 +144,8 @@ void AudioPluginAudioProcessorEditor::resized()
 
     juce::ignoreUnused(headerSection, miniMapSection, sliderSection);
 
-    if (openGLBackground->isSignalFlowChartVisible()) {
+    if (openGLBackground->isSignalFlowChartVisible())
+    {
         auto window = getLocalBounds();
         window.removeFromTop(headerSection.getHeight() + 20);
         window.removeFromBottom(footerComponent.getHeight() + 20);
@@ -147,7 +157,7 @@ void AudioPluginAudioProcessorEditor::resized()
     transientViewer.setBounds(710, 450, 163, 163);
     advancedParameterControl.setBounds(765, 60, 600, 600);
 
-    auto areaParameter = getLocalBounds().removeFromRight(static_cast<int>((float)getWidth()*0.4f));
+    auto areaParameter = getLocalBounds().removeFromRight(static_cast<int>((float)getWidth() * 0.4f));
     areaParameter.removeFromTop(40);
     parameterControl.setBounds(areaParameter);
 
@@ -159,58 +169,68 @@ void AudioPluginAudioProcessorEditor::resized()
 
     processorRef.onNetwork1NameChange(processorRef.network1Name.toString());
     processorRef.onNetwork2NameChange(processorRef.network2Name.toString());
-
 }
 
-void AudioPluginAudioProcessorEditor::parameterChanged(const juce::String &parameterID, float newValue) {
+void AudioPluginAudioProcessorEditor::parameterChanged(const juce::String &parameterID, float newValue)
+{
     parameterControl.parameterChanged(parameterID, newValue);
-    if (parameterID == PluginParameters::SELECT_NETWORK1_ID.getParamID() && newValue == 1.f) {
+    if (parameterID == PluginParameters::SELECT_NETWORK1_ID.getParamID() && newValue == 1.f)
+    {
         juce::Component::SafePointer<AudioPluginAudioProcessorEditor> safeThis(this);
         juce::MessageManager::callAsync([safeThis]()
-        {
+                                        {
             if (safeThis != nullptr)
-                safeThis->fileChooserManager.openFileChooserForNetwork(1, safeThis.getComponent());
-        });
-    } else if (parameterID == PluginParameters::SELECT_NETWORK2_ID.getParamID() && newValue == 1.f) {
+                safeThis->fileChooserManager.openFileChooserForNetwork(1, safeThis.getComponent()); });
+    }
+    else if (parameterID == PluginParameters::SELECT_NETWORK2_ID.getParamID() && newValue == 1.f)
+    {
         juce::Component::SafePointer<AudioPluginAudioProcessorEditor> safeThis(this);
         juce::MessageManager::callAsync([safeThis]()
-        {
+                                        {
             if (safeThis != nullptr)
-                safeThis->fileChooserManager.openFileChooserForNetwork(2, safeThis.getComponent());
-        });
+                safeThis->fileChooserManager.openFileChooserForNetwork(2, safeThis.getComponent()); });
     }
 }
 
 // Tooltips
-void AudioPluginAudioProcessorEditor::mouseEnter(const juce::MouseEvent &event) {
+void AudioPluginAudioProcessorEditor::mouseEnter(const juce::MouseEvent &event)
+{
     auto component = event.originalComponent;
     auto it = tooltipMap.find(component);
-    if (it != tooltipMap.end()) {
+    if (it != tooltipMap.end())
+    {
         footerComponent.setTooltipText(it->second);
     }
 }
 
-void AudioPluginAudioProcessorEditor::mouseExit(const juce::MouseEvent &) {
+void AudioPluginAudioProcessorEditor::mouseExit(const juce::MouseEvent &)
+{
     footerComponent.setTooltipText("");
 }
 
-void AudioPluginAudioProcessorEditor::initializeTooltipMap() {
+void AudioPluginAudioProcessorEditor::initializeTooltipMap()
+{
     tooltipMap.clear();
 
     // Check if all required components are loaded
-    if (!xyPadComponents) {
+    if (!xyPadComponents)
+    {
         throw std::runtime_error("xyPadComponents not loaded");
     }
-    if (!parameterControlComponents) {
+    if (!parameterControlComponents)
+    {
         throw std::runtime_error("parameterControlComponents not loaded");
     }
-    if (!headerComponents) {
+    if (!headerComponents)
+    {
         throw std::runtime_error("headerComponents not loaded");
     }
-    if (!advancedParameterControlComponents) {
+    if (!advancedParameterControlComponents)
+    {
         throw std::runtime_error("advancedParameterControlComponents not loaded");
     }
-    if (!openGLBackground) {
+    if (!openGLBackground)
+    {
         throw std::runtime_error("openGLBackground not loaded");
     }
 
@@ -256,12 +276,12 @@ void AudioPluginAudioProcessorEditor::initializeTooltipMap() {
     tooltipMap[advancedParameterControlComponents[14]] = "RAVE Network 2 Grain Pitch";
     tooltipMap[advancedParameterControlComponents[15]] = "RAVE Network 2 Grain Delay Dry/Wet";
 
-    auto* labels = openGLBackground->getLabels();
-    if (labels) {
+    auto *labels = openGLBackground->getLabels();
+    if (labels)
+    {
         tooltipMap[&labels->sharp] = "Low Cut Filter Frequency";
         tooltipMap[&labels->attack] = "Transient Shaper: Attack";
         tooltipMap[&labels->smooth] = "High Cut Filter Frequency";
         tooltipMap[&labels->sustain] = "Transient Shaper: Sustain";
     }
 }
-

--- a/source/PluginEditor.cpp
+++ b/source/PluginEditor.cpp
@@ -165,9 +165,19 @@ void AudioPluginAudioProcessorEditor::resized()
 void AudioPluginAudioProcessorEditor::parameterChanged(const juce::String &parameterID, float newValue) {
     parameterControl.parameterChanged(parameterID, newValue);
     if (parameterID == PluginParameters::SELECT_NETWORK1_ID.getParamID() && newValue == 1.f) {
-        fileChooserManager.openFileChooserForNetwork(1);
+        juce::Component::SafePointer<AudioPluginAudioProcessorEditor> safeThis(this);
+        juce::MessageManager::callAsync([safeThis]()
+        {
+            if (safeThis != nullptr)
+                safeThis->fileChooserManager.openFileChooserForNetwork(1, safeThis.getComponent());
+        });
     } else if (parameterID == PluginParameters::SELECT_NETWORK2_ID.getParamID() && newValue == 1.f) {
-        fileChooserManager.openFileChooserForNetwork(2);
+        juce::Component::SafePointer<AudioPluginAudioProcessorEditor> safeThis(this);
+        juce::MessageManager::callAsync([safeThis]()
+        {
+            if (safeThis != nullptr)
+                safeThis->fileChooserManager.openFileChooserForNetwork(2, safeThis.getComponent());
+        });
     }
 }
 

--- a/source/dsp/onnx/InferenceThread.cpp
+++ b/source/dsp/onnx/InferenceThread.cpp
@@ -106,55 +106,88 @@ void InferenceThread::modelInputSizeChanged(int newModelInputSize) {
     onnxOutputData.resize(newModelInputSize, 0.0f);
 }
 
+bool InferenceThread::stopInferenceThreadAndWait()
+{
+    if (! isThreadRunning())
+        return true;
+
+    stopThread(10000);
+
+    constexpr int maxWaitMs = 10000;
+    const auto deadline = juce::Time::getMillisecondCounter() + (uint32_t) maxWaitMs;
+
+    while (isThreadRunning())
+    {
+        if (juce::Time::getMillisecondCounter() >= deadline)
+        {
+            std::cout << "InferenceThread: timed out waiting for inference thread to stop" << std::endl;
+            return false;
+        }
+
+        juce::Thread::sleep(1);
+    }
+
+    return true;
+}
+
 void InferenceThread::loadExternalModel(juce::File modelPath) {
     loadingModel = true;
 
-    if (isThreadRunning()) {
-        stopThread(10);
+    struct LoadingModelGuard
+    {
+        InferenceThread& owner;
+        ~LoadingModelGuard() { owner.loadingModel = false; }
+    } loadingGuard { *this };
 
-        while (!isThreadRunning()) {
-            juce::Time::waitForMillisecondCounter(juce::Time::getMillisecondCounter() + 1);
-        }
-    }
+    if (! stopInferenceThreadAndWait())
+        return;
 
+    try
+    {
 #if JUCE_WINDOWS
-    auto modelPathToLoad = modelPath.getFullPathName().toStdString();
-    std::wstring modelWideStr = std::wstring(modelPathToLoad.begin(), modelPathToLoad.end());
-    const wchar_t* modelWideCStr = modelWideStr.c_str();
+        auto modelPathToLoad = modelPath.getFullPathName().toStdString();
+        std::wstring modelWideStr = std::wstring(modelPathToLoad.begin(), modelPathToLoad.end());
+        const wchar_t* modelWideCStr = modelWideStr.c_str();
 
-    session = Ort::Session(env,
-                       modelWideCStr,
-                       sessionOptions);
+        session = Ort::Session(env,
+                           modelWideCStr,
+                           sessionOptions);
 #else
 
-    auto modelPathToLoad = modelPath.getFullPathName().toStdString();
-    const char* modelCStr = modelPathToLoad.c_str();
+        auto modelPathToLoad = modelPath.getFullPathName().toStdString();
+        const char* modelCStr = modelPathToLoad.c_str();
 
-    session = Ort::Session(env,
-                           modelCStr,
-                           sessionOptions);
+        session = Ort::Session(env,
+                               modelCStr,
+                               sessionOptions);
 #endif
 
-    prepare(last_spec);
+        prepare(last_spec);
 
-    auto shape = getInputShape(&session);
+        auto shape = getInputShape(&session);
 
-    for (int i = 0; i < shape.size(); ++i) {
-//        std::cout << "shape[" <<  i << "]: " << shape[i] << std::endl;
+        for (int i = 0; i < shape.size(); ++i) {
+    //        std::cout << "shape[" <<  i << "]: " << shape[i] << std::endl;
+        }
+        onModelLoaded(modelPath.getFileNameWithoutExtension());
     }
-    onModelLoaded(modelPath.getFileNameWithoutExtension());
-    loadingModel = false;
+    catch (const Ort::Exception& e)
+    {
+        std::cout << e.what() << std::endl;
+    }
+    catch (const std::exception& e)
+    {
+        std::cout << e.what() << std::endl;
+    }
 }
 
 void InferenceThread::loadInternalModel(RaveModel modelToLoad) {
     loadingModel = true;
 
-    if (isThreadRunning()) {
-        stopThread(10);
-
-        while (!isThreadRunning()) {
-            juce::Time::waitForMillisecondCounter(juce::Time::getMillisecondCounter() + 1);
-        }
+    if (! stopInferenceThreadAndWait())
+    {
+        loadingModel = false;
+        return;
     }
 
     switch (modelToLoad) {

--- a/source/dsp/onnx/InferenceThread.h
+++ b/source/dsp/onnx/InferenceThread.h
@@ -39,6 +39,7 @@ private:
     void modelInputSizeChanged(int newModelInputSize);
     void loadExternalModel(juce::File modelPath);
     void loadInternalModel(RaveModel modelToLoad);
+    bool stopInferenceThreadAndWait();
     std::vector<int> getInputShape(Ort::Session *sess);
 
 private:

--- a/source/dsp/onnx/WarningWindow.h
+++ b/source/dsp/onnx/WarningWindow.h
@@ -6,64 +6,75 @@
 #define VAESYNTH_WARNINGWINDOW_H
 
 #include "JuceHeader.h"
-#include "../../utils/colors.h"
 
-enum WarningType {
+enum WarningType
+{
     SampleRateWarning,
     SystemTooSlow,
     UnsupportedFileType
 };
 
-class WarningWindow {
+class WarningWindow
+{
 public:
-    WarningWindow() {
-
-    }
-    void showWarningWindow(WarningType type) {
-
+    void showWarningWindow(WarningType type, const juce::String& expectedFilePatterns = {})
+    {
         juce::String errorMessage;
         juce::String title;
 
-        switch (type) {
-            case SampleRateWarning:
-                title = "Warning: unsupported sample rate";
-                errorMessage = "This plugin is still in alpha. At the moment only a sample rate of 48kHz is supported.";
-                break;
-            case SystemTooSlow:
-                title = "Warning: system load to high";
-                errorMessage = "It seems that this system is not fast enough to process the audio data. Try to only use one network.";
-                break;
-            case UnsupportedFileType:
-                title = "Warning: Unsupported file type";
-                errorMessage = "It seems that you have tried to load an unsupported file (i.e. a shortcut). Please try again.";
+        switch (type)
+        {
+        case SampleRateWarning:
+            title = "Warning: unsupported sample rate";
+            errorMessage = "This plugin is still in alpha. At the moment only a sample rate of 48kHz is supported.";
+            break;
+        case SystemTooSlow:
+            title = "Warning: system load too high";
+            errorMessage = "It seems that this system is not fast enough to process the audio data. Try to only use one network.";
+            break;
+        case UnsupportedFileType:
+            title = "Could not load file";
+            errorMessage = makeUnsupportedFileMessage(expectedFilePatterns);
+            break;
         }
 
-        juce::AlertWindow window {title, errorMessage, juce::MessageBoxIconType::NoIcon};
-        setLookAndFeel(window);
-
-        auto options = juce::MessageBoxOptions()
+        juce::AlertWindow::showAsync(
+            juce::MessageBoxOptions()
                 .withTitle(title)
                 .withMessage(errorMessage)
                 .withIconType(juce::MessageBoxIconType::NoIcon)
-                .withButton("OK") ;
-        window.showAsync(options, nullptr);
-
+                .withButton("OK"),
+            nullptr);
     }
 
 private:
-    void setLookAndFeel(juce::AlertWindow& window) {
-        auto& lookAndFeel = window.getLookAndFeel();
+    static juce::String formatExpectedExtensions(const juce::String& filePatterns)
+    {
+        juce::StringArray extensions;
+        extensions.addTokens(filePatterns, ";,", "*");
 
-        lookAndFeel.setColour(juce::AlertWindow::ColourIds::outlineColourId, juce::Colour::fromString(ColorPallete::BG));
-        lookAndFeel.setColour(juce::AlertWindow::ColourIds::backgroundColourId, juce::Colour::fromString(ColorPallete::BG));
-        lookAndFeel.setColour(juce::AlertWindow::ColourIds::textColourId, juce::Colour::fromString(ColorPallete::TEXT2));
-        lookAndFeel.setColour(juce::TextButton::ColourIds::buttonOnColourId, juce::Colour::fromString(ColorPallete::TEXT2));
-        lookAndFeel.setColour(juce::TextButton::ColourIds::buttonOnColourId, juce::Colour::fromString(ColorPallete::TEXT2));
-        lookAndFeel.setColour(juce::TextButton::ColourIds::textColourOnId, juce::Colour::fromString(ColorPallete::BG));
-        lookAndFeel.setColour(juce::TextButton::ColourIds::textColourOffId, juce::Colour::fromString(ColorPallete::BG));
+        juce::StringArray formatted;
 
-        window.setLookAndFeel(&lookAndFeel);
+        for (auto ext : extensions)
+        {
+            ext = ext.trim().trimCharactersAtStart("*.");
+
+            if (ext.isNotEmpty())
+                formatted.add("." + ext);
+        }
+
+        return formatted.joinIntoString(" or ");
+    }
+
+    static juce::String makeUnsupportedFileMessage(const juce::String& expectedFilePatterns)
+    {
+        const auto extensions = formatExpectedExtensions(expectedFilePatterns);
+
+        if (extensions.isNotEmpty())
+            return "Please choose a valid " + extensions + " file. Shortcuts and other file types cannot be loaded.";
+
+        return "Please choose a valid file with a supported extension. Shortcuts and other file types cannot be loaded.";
     }
 };
 
-#endif //VAESYNTH_WARNINGWINDOW_H
+#endif // VAESYNTH_WARNINGWINDOW_H

--- a/source/ui/CustomComponents/Footer/FooterComponent.cpp
+++ b/source/ui/CustomComponents/Footer/FooterComponent.cpp
@@ -3,76 +3,70 @@
 //
 
 #include "FooterComponent.h"
+#include "BuildInfo.h"
 
-FooterComponent::FooterComponent(AudioPluginAudioProcessor &p, juce::AudioProcessorValueTreeState &parameters) : processor(p), parameters(parameters) {
+FooterComponent::FooterComponent(AudioPluginAudioProcessor &p, juce::AudioProcessorValueTreeState &parameters) : processor(p), parameters(parameters)
+{
     updateSpecs();
     startTimerHz(1);
     setLookAndFeel(&customFontLookAndFeel);
-    //font = CustomFontLookAndFeel::getCustomFont();
+    // font = CustomFontLookAndFeel::getCustomFont();
 
-    //cpuLabel.setFont(font);
-    cpuLabel.setColour(juce::Label::ColourIds::textColourId, juce::Colour::fromString(ColorPallete::TEXT2));
-    addAndMakeVisible(cpuLabel);
+    // cpuLabel.setFont(font);
+    statusLabel.setColour(juce::Label::ColourIds::textColourId, juce::Colour::fromString(ColorPallete::TEXT2));
+    addAndMakeVisible(statusLabel);
 
-    //latencyLabel.setFont(font);
-    latencyLabel.setColour(juce::Label::ColourIds::textColourId, juce::Colour::fromString(ColorPallete::TEXT2));
-    addAndMakeVisible(latencyLabel);
-
-    //tooltipLabel.setFont(font);
+    // tooltipLabel.setFont(font);
     tooltipLabel.setColour(juce::Label::ColourIds::textColourId, juce::Colour::fromString(ColorPallete::TEXT2));
     addAndMakeVisible(tooltipLabel);
 }
 
-FooterComponent::~FooterComponent() {
+FooterComponent::~FooterComponent()
+{
     stopTimer();
     setLookAndFeel(nullptr);
 }
 
-
-void FooterComponent::resized() {
+void FooterComponent::resized()
+{
     auto r = getLocalBounds();
 
     r.removeFromRight(8);
     r.removeFromLeft(8);
     r.removeFromBottom(5);
 
-
-    auto cpuSection = r.removeFromRight(130);
-    cpuSection.removeFromRight(37);
-    cpuLabel.setBounds(cpuSection);
-    cpuLabel.setJustificationType(juce::Justification::right);
-
-    auto latencySection = r.removeFromRight(130);
-    latencyLabel.setBounds(latencySection);
-    latencyLabel.setJustificationType(juce::Justification::right);
-
     r.removeFromLeft(35);
     auto tooltipSection = r.removeFromLeft(500);
     tooltipLabel.setBounds(tooltipSection);
+
+    statusLabel.setBounds(r);
+    statusLabel.setJustificationType(juce::Justification::right);
 }
 
-void FooterComponent::paint(juce::Graphics &) {
+void FooterComponent::paint(juce::Graphics &)
+{
 }
 
-void FooterComponent::updateSpecs(){
+void FooterComponent::updateSpecs()
+{
     latencySamples = processor.getLatencySamples();
     sampleRate = static_cast<int>(processor.getSampleRate());
     latencySeconds = (float)latencySamples / float(sampleRate);
 
-    //processorUse = processor.getCpuLoad();
     processorUse = processor.getCpuLoad();
 
-    std::string cpuString = "CPU: " + std::to_string((int)processorUse ) + " %";
-    cpuLabel.setText(cpuString, juce::dontSendNotification);
-    std::string latencyString = "Latency: " + std::to_string(int(latencySeconds * 1000)) + " ms";
-    latencyLabel.setText(latencyString, juce::dontSendNotification);
+    const auto statusText = juce::String("Latency: ") + juce::String((int)(latencySeconds * 1000)) + " ms | CPU: "
+                          + juce::String((int)processorUse) + "% | " + BuildInfo::commitHash + " \u2022 "
+                          + BuildInfo::commitDate;
+    statusLabel.setText(statusText, juce::dontSendNotification);
 }
 
-void FooterComponent::timerCallback() {
+void FooterComponent::timerCallback()
+{
     updateSpecs();
 }
 
-void FooterComponent::setTooltipText(juce::String newText) {
+void FooterComponent::setTooltipText(juce::String newText)
+{
     tooltipLabel.setText(newText, juce::dontSendNotification);
 }
-

--- a/source/ui/CustomComponents/Footer/FooterComponent.h
+++ b/source/ui/CustomComponents/Footer/FooterComponent.h
@@ -11,25 +11,26 @@
 #include "../../../PluginProcessor.h"
 #include "../../../ui/LookAndFeel/CustomFontLookAndFeel.h"
 
-class FooterComponent : public juce::Component, juce::Timer {
+class FooterComponent : public juce::Component, juce::Timer
+{
 public:
-    FooterComponent(AudioPluginAudioProcessor& p, juce::AudioProcessorValueTreeState& parameters);
+    FooterComponent(AudioPluginAudioProcessor &p, juce::AudioProcessorValueTreeState &parameters);
     ~FooterComponent();
 
     void resized() override;
-    void paint(juce::Graphics& g) override;
+    void paint(juce::Graphics &g) override;
     void timerCallback() override;
 
     void updateSpecs();
 
     void setTooltipText(juce::String newText);
+
 private:
-    AudioPluginAudioProcessor& processor;
-    juce::AudioProcessorValueTreeState& parameters;
+    AudioPluginAudioProcessor &processor;
+    juce::AudioProcessorValueTreeState &parameters;
 
     juce::Label tooltipLabel;
-    juce::Label latencyLabel;
-    juce::Label cpuLabel;
+    juce::Label statusLabel;
 
     int latencySamples = 0;
     int sampleRate = 0;
@@ -38,8 +39,6 @@ private:
 
     CustomFontLookAndFeel customFontLookAndFeel;
     juce::Font font;
-
 };
 
-
-#endif //SCYCLONE_FOOTERCOMPONENT_H
+#endif // SCYCLONE_FOOTERCOMPONENT_H

--- a/source/ui/CustomComponents/Footer/FooterComponent.h
+++ b/source/ui/CustomComponents/Footer/FooterComponent.h
@@ -6,6 +6,7 @@
 #define SCYCLONE_FOOTERCOMPONENT_H
 
 #include "JuceHeader.h"
+#include "../../../utils/colors.h"
 #include "../../../PluginParameters.h"
 #include "../../../PluginProcessor.h"
 #include "../../../ui/LookAndFeel/CustomFontLookAndFeel.h"

--- a/source/utils/FileChooserManager.cpp
+++ b/source/utils/FileChooserManager.cpp
@@ -1,71 +1,194 @@
 #include "FileChooserManager.h"
 
+namespace
+{
+    struct ChooserOpenGuard
+    {
+        std::shared_ptr<std::atomic<bool>> flag;
+
+        explicit ChooserOpenGuard(std::shared_ptr<std::atomic<bool>> openFlag)
+            : flag(std::move(openFlag))
+        {
+        }
+
+        ~ChooserOpenGuard()
+        {
+            if (flag != nullptr)
+                flag->store(false);
+        }
+    };
+
+    // Clears chooserOpen if launchAsync never invokes its callback (e.g. FileChooser destroyed early).
+    struct ChooserOpenSession
+    {
+        std::shared_ptr<std::atomic<bool>> flag;
+        bool callbackStarted = false;
+
+        explicit ChooserOpenSession(std::shared_ptr<std::atomic<bool>> openFlag)
+            : flag(std::move(openFlag))
+        {
+        }
+
+        void onCallbackStarted()
+        {
+            callbackStarted = true;
+        }
+
+        ~ChooserOpenSession()
+        {
+            if (! callbackStarted && flag != nullptr)
+                flag->store(false);
+        }
+    };
+
+    bool isPlatformShortcut(const juce::File& file)
+    {
+       #if JUCE_WINDOWS
+        return file.isShortcut();
+       #else
+        return false;
+       #endif
+    }
+
+    juce::File getChosenLocalFile(const juce::FileChooser& chooser)
+    {
+        for (const auto& result : chooser.getURLResults())
+        {
+            if (result.isLocalFile())
+                return result.getLocalFile();
+        }
+
+        return {};
+    }
+
+    bool fileHasValidExtension(const juce::File& file, const juce::String& filePatterns)
+    {
+        juce::StringArray validExtensions;
+        validExtensions.addTokens(filePatterns, ";,", "*");
+
+        for (auto& ext : validExtensions)
+        {
+            ext = ext.trimCharactersAtStart("*.");
+            if (file.hasFileExtension(ext))
+                return true;
+        }
+
+        return false;
+    }
+
+    bool isSupportedFile(const juce::File& file, const juce::String& filePatterns)
+    {
+        return file.existsAsFile()
+            && file.getSize() > 0
+            && ! isPlatformShortcut(file)
+            && fileHasValidExtension(file, filePatterns);
+    }
+
+    bool isDestroyed(const std::shared_ptr<std::atomic<bool>>& alive,
+                     const std::shared_ptr<std::atomic<bool>>& open)
+    {
+        if (alive->load())
+            return false;
+
+        open->store(false);
+        return true;
+    }
+
+    void handleAsyncFileChooserResult(const juce::FileChooser& chooser,
+                                      const std::shared_ptr<std::atomic<bool>>& alive,
+                                      const std::shared_ptr<std::atomic<bool>>& open,
+                                      const std::shared_ptr<ChooserOpenSession>& session,
+                                      const juce::String& filePatterns,
+                                      const std::function<void(const juce::File&)>& onValidFileChosenCallback,
+                                      juce::File& lastOpenedFolder,
+                                      WarningWindow& warningWindow)
+    {
+        if (isDestroyed(alive, open))
+            return;
+
+        session->onCallbackStarted();
+        ChooserOpenGuard chooserGuard { open };
+
+        if (chooser.getURLResults().isEmpty())
+            return;
+
+        const auto chosen = getChosenLocalFile(chooser);
+
+        if (isDestroyed(alive, open))
+            return;
+
+        if (chosen.existsAsFile())
+            lastOpenedFolder = chosen.getParentDirectory();
+
+        if (isDestroyed(alive, open))
+            return;
+
+        if (isSupportedFile(chosen, filePatterns))
+            onValidFileChosenCallback(chosen);
+        else
+            warningWindow.showWarningWindow(UnsupportedFileType, filePatterns);
+    }
+}
+
 FileChooserManager::FileChooserManager(AudioPluginAudioProcessor& processor)
-        : processorRef(processor)
+        : processorRef(processor),
+          callbackAlive(std::make_shared<std::atomic<bool>>(true)),
+          chooserOpen(std::make_shared<std::atomic<bool>>(false))
 {
     lastOpenedFolder = juce::File::getSpecialLocation(juce::File::SpecialLocationType::userHomeDirectory);
 }
 
-// Generalized function, atm for single files only
-void FileChooserManager::openFileChooser(const juce::String& dialogTitle,
-                     const juce::File& initialDirectory,
-                     const juce::String& filePatterns,
-                     std::function<void(const juce::File&)> onValidFileChosenCallback)
+FileChooserManager::~FileChooserManager()
 {
-    if (lastOpenedFolder.exists()) {
-        dirToOpen = lastOpenedFolder;
-    } else {
-        dirToOpen = initialDirectory;;
-    }
-
-    fileChooser = std::make_unique<juce::FileChooser>(dialogTitle, dirToOpen, filePatterns, true);
-
-    fileChooser->launchAsync(juce::FileBrowserComponent::openMode | juce::FileBrowserComponent::canSelectFiles,
-                             [this, filePatterns, onValidFileChosenCallback](const juce::FileChooser& chooser)
-                             {
-                                 juce::File chosen;
-                                 auto results = chooser.getURLResults();
-
-                                 // Check if the results are empty (user closed without selecting a file)
-                                 if (results.isEmpty())
-                                 {
-                                     return;
-                                 }
-
-                                 for (const auto& result : results)
-                                 {
-                                     if (result.isLocalFile())
-                                     {
-                                         chosen = result.getLocalFile();
-                                         lastOpenedFolder = chosen.getParentDirectory();
-                                         break; // We only need one valid file
-                                     }
-                                     else {
-                                         return;
-                                     }
-                                 }
-
-                                 // Check if the file is valid (non-empty, correct extension based on filePatterns)
-                                 if (chosen.getSize() != 0 && fileHasValidExtension(chosen, filePatterns))
-                                     onValidFileChosenCallback(chosen);
-                                 else
-                                     warningWindow.showWarningWindow(UnsupportedFileType);
-                             });
+    callbackAlive->store(false);
+    chooserOpen->store(false);
 }
 
-bool FileChooserManager::fileHasValidExtension(const juce::File& file, const juce::String& filePatterns)
+// Generalized function, atm for single files only
+void FileChooserManager::openFileChooser(const juce::String& dialogTitle,
+                                         const juce::File& initialDirectory,
+                                         const juce::String& filePatterns,
+                                         std::function<void(const juce::File&)> onValidFileChosenCallback)
 {
-    juce::StringArray validExtensions;
-    validExtensions.addTokens(filePatterns, ";,", "*");
+    if (chooserOpen->exchange(true))
+        return;
 
-    for (auto& ext : validExtensions)
+    auto session = std::make_shared<ChooserOpenSession>(chooserOpen);
+
+    if (lastOpenedFolder.exists())
+        dirToOpen = lastOpenedFolder;
+    else
+        dirToOpen = initialDirectory;
+
+    try
     {
-        ext = ext.trimCharactersAtStart("*."); // Remove wildcard characters
-        if (file.hasFileExtension(ext))
-            return true;
-    }
+        fileChooser = std::make_unique<juce::FileChooser>(dialogTitle, dirToOpen, filePatterns, true);
 
-    return false;
+        fileChooser->launchAsync(juce::FileBrowserComponent::openMode | juce::FileBrowserComponent::canSelectFiles,
+                                 [alive = callbackAlive,
+                                  open = chooserOpen,
+                                  session,
+                                  filePatterns,
+                                  onValidFileChosenCallback,
+                                  lastOpenedFolder = std::ref(lastOpenedFolder),
+                                  warningWindow = std::ref(warningWindow)](const juce::FileChooser& chooser)
+                                 {
+                                     handleAsyncFileChooserResult(chooser,
+                                                                  alive,
+                                                                  open,
+                                                                  session,
+                                                                  filePatterns,
+                                                                  onValidFileChosenCallback,
+                                                                  lastOpenedFolder.get(),
+                                                                  warningWindow.get());
+                                 });
+    }
+    catch (...)
+    {
+        session->onCallbackStarted();
+        chooserOpen->store(false);
+        throw;
+    }
 }
 
 // Use case: Network-specific file chooser

--- a/source/utils/FileChooserManager.cpp
+++ b/source/utils/FileChooserManager.cpp
@@ -36,23 +36,23 @@ namespace
 
         ~ChooserOpenSession()
         {
-            if (! callbackStarted && flag != nullptr)
+            if (!callbackStarted && flag != nullptr)
                 flag->store(false);
         }
     };
 
-    bool isPlatformShortcut(const juce::File& file)
+    bool isPlatformShortcut(const juce::File &file)
     {
-       #if JUCE_WINDOWS
+#if JUCE_WINDOWS
         return file.isShortcut();
-       #else
+#else
         return false;
-       #endif
+#endif
     }
 
-    juce::File getChosenLocalFile(const juce::FileChooser& chooser)
+    juce::File getChosenLocalFile(const juce::FileChooser &chooser)
     {
-        for (const auto& result : chooser.getURLResults())
+        for (const auto &result : chooser.getURLResults())
         {
             if (result.isLocalFile())
                 return result.getLocalFile();
@@ -61,12 +61,12 @@ namespace
         return {};
     }
 
-    bool fileHasValidExtension(const juce::File& file, const juce::String& filePatterns)
+    bool fileHasValidExtension(const juce::File &file, const juce::String &filePatterns)
     {
         juce::StringArray validExtensions;
         validExtensions.addTokens(filePatterns, ";,", "*");
 
-        for (auto& ext : validExtensions)
+        for (auto &ext : validExtensions)
         {
             ext = ext.trimCharactersAtStart("*.");
             if (file.hasFileExtension(ext))
@@ -76,16 +76,13 @@ namespace
         return false;
     }
 
-    bool isSupportedFile(const juce::File& file, const juce::String& filePatterns)
+    bool isSupportedFile(const juce::File &file, const juce::String &filePatterns)
     {
-        return file.existsAsFile()
-            && file.getSize() > 0
-            && ! isPlatformShortcut(file)
-            && fileHasValidExtension(file, filePatterns);
+        return file.existsAsFile() && file.getSize() > 0 && !isPlatformShortcut(file) && fileHasValidExtension(file, filePatterns);
     }
 
-    bool isDestroyed(const std::shared_ptr<std::atomic<bool>>& alive,
-                     const std::shared_ptr<std::atomic<bool>>& open)
+    bool isDestroyed(const std::shared_ptr<std::atomic<bool>> &alive,
+                     const std::shared_ptr<std::atomic<bool>> &open)
     {
         if (alive->load())
             return false;
@@ -94,20 +91,20 @@ namespace
         return true;
     }
 
-    void handleAsyncFileChooserResult(const juce::FileChooser& chooser,
-                                      const std::shared_ptr<std::atomic<bool>>& alive,
-                                      const std::shared_ptr<std::atomic<bool>>& open,
-                                      const std::shared_ptr<ChooserOpenSession>& session,
-                                      const juce::String& filePatterns,
-                                      const std::function<void(const juce::File&)>& onValidFileChosenCallback,
-                                      juce::File& lastOpenedFolder,
-                                      WarningWindow& warningWindow)
+    void handleAsyncFileChooserResult(const juce::FileChooser &chooser,
+                                      const std::shared_ptr<std::atomic<bool>> &alive,
+                                      const std::shared_ptr<std::atomic<bool>> &open,
+                                      const std::shared_ptr<ChooserOpenSession> &session,
+                                      const juce::String &filePatterns,
+                                      const std::function<void(const juce::File &)> &onValidFileChosenCallback,
+                                      juce::File &lastOpenedFolder,
+                                      WarningWindow &warningWindow)
     {
         if (isDestroyed(alive, open))
             return;
 
         session->onCallbackStarted();
-        ChooserOpenGuard chooserGuard { open };
+        ChooserOpenGuard chooserGuard{open};
 
         if (chooser.getURLResults().isEmpty())
             return;
@@ -130,10 +127,10 @@ namespace
     }
 }
 
-FileChooserManager::FileChooserManager(AudioPluginAudioProcessor& processor)
-        : processorRef(processor),
-          callbackAlive(std::make_shared<std::atomic<bool>>(true)),
-          chooserOpen(std::make_shared<std::atomic<bool>>(false))
+FileChooserManager::FileChooserManager(AudioPluginAudioProcessor &processor)
+    : processorRef(processor),
+      callbackAlive(std::make_shared<std::atomic<bool>>(true)),
+      chooserOpen(std::make_shared<std::atomic<bool>>(false))
 {
     lastOpenedFolder = juce::File::getSpecialLocation(juce::File::SpecialLocationType::userHomeDirectory);
 }
@@ -145,11 +142,25 @@ FileChooserManager::~FileChooserManager()
 }
 
 // Generalized function, atm for single files only
-void FileChooserManager::openFileChooser(const juce::String& dialogTitle,
-                                         const juce::File& initialDirectory,
-                                         const juce::String& filePatterns,
-                                         std::function<void(const juce::File&)> onValidFileChosenCallback)
+void FileChooserManager::openFileChooser(const juce::String &dialogTitle,
+                                         const juce::File &initialDirectory,
+                                         const juce::String &filePatterns,
+                                         std::function<void(const juce::File &)> onValidFileChosenCallback,
+                                         juce::Component *parentComponent)
 {
+    if (!juce::MessageManager::getInstance()->isThisTheMessageThread())
+    {
+        auto alive = callbackAlive;
+        juce::MessageManager::callAsync([this, alive, dialogTitle, initialDirectory, filePatterns,
+                                         onValidFileChosenCallback, parentComponent]()
+                                        {
+            if (! alive->load())
+                return;
+
+            openFileChooser(dialogTitle, initialDirectory, filePatterns, onValidFileChosenCallback, parentComponent); });
+        return;
+    }
+
     if (chooserOpen->exchange(true))
         return;
 
@@ -162,16 +173,16 @@ void FileChooserManager::openFileChooser(const juce::String& dialogTitle,
 
     try
     {
-        fileChooser = std::make_unique<juce::FileChooser>(dialogTitle, dirToOpen, filePatterns, true);
+        fileChooser = std::make_unique<juce::FileChooser>(dialogTitle,
+                                                          dirToOpen,
+                                                          filePatterns,
+                                                          true,
+                                                          false,
+                                                          parentComponent);
 
         fileChooser->launchAsync(juce::FileBrowserComponent::openMode | juce::FileBrowserComponent::canSelectFiles,
-                                 [alive = callbackAlive,
-                                  open = chooserOpen,
-                                  session,
-                                  filePatterns,
-                                  onValidFileChosenCallback,
-                                  lastOpenedFolder = std::ref(lastOpenedFolder),
-                                  warningWindow = std::ref(warningWindow)](const juce::FileChooser& chooser)
+                                 [this, alive = callbackAlive, open = chooserOpen, session, filePatterns, onValidFileChosenCallback](
+                                     const juce::FileChooser &chooser)
                                  {
                                      handleAsyncFileChooserResult(chooser,
                                                                   alive,
@@ -179,8 +190,8 @@ void FileChooserManager::openFileChooser(const juce::String& dialogTitle,
                                                                   session,
                                                                   filePatterns,
                                                                   onValidFileChosenCallback,
-                                                                  lastOpenedFolder.get(),
-                                                                  warningWindow.get());
+                                                                  lastOpenedFolder,
+                                                                  warningWindow);
                                  });
     }
     catch (...)
@@ -192,7 +203,7 @@ void FileChooserManager::openFileChooser(const juce::String& dialogTitle,
 }
 
 // Use case: Network-specific file chooser
-void FileChooserManager::openFileChooserForNetwork(int networkID)
+void FileChooserManager::openFileChooserForNetwork(int networkID, juce::Component *parentComponent)
 {
     if (networkID != 1 && networkID != 2)
     {
@@ -200,7 +211,7 @@ void FileChooserManager::openFileChooserForNetwork(int networkID)
         return;
     }
 
-    auto onFileChosen = [this, networkID](const juce::File& file)
+    auto onFileChosen = [this, networkID](const juce::File &file)
     {
         processorRef.loadExternalModel(file.getFullPathName(), networkID);
     };
@@ -208,5 +219,6 @@ void FileChooserManager::openFileChooserForNetwork(int networkID)
     openFileChooser("Choose a model file...",
                     juce::File::getSpecialLocation(juce::File::SpecialLocationType::userHomeDirectory),
                     "*.ort",
-                    onFileChosen);
+                    onFileChosen,
+                    parentComponent);
 }

--- a/source/utils/FileChooserManager.h
+++ b/source/utils/FileChooserManager.h
@@ -6,20 +6,21 @@
 class FileChooserManager
 {
 public:
-    FileChooserManager(AudioPluginAudioProcessor& processor);
+    FileChooserManager(AudioPluginAudioProcessor &processor);
     ~FileChooserManager();
 
     // Generalized file chooser function, atm for single files only
-    void openFileChooser(const juce::String& dialogTitle,
-                         const juce::File& initialDirectory,
-                         const juce::String& filePatterns,
-                         std::function<void(const juce::File&)> onValidFileChosenCallback);
+    void openFileChooser(const juce::String &dialogTitle,
+                         const juce::File &initialDirectory,
+                         const juce::String &filePatterns,
+                         std::function<void(const juce::File &)> onValidFileChosenCallback,
+                         juce::Component *parentComponent = nullptr);
 
     // Network-specific file chooser function, using openFileChooser
-    void openFileChooserForNetwork(int networkID);
+    void openFileChooserForNetwork(int networkID, juce::Component *parentComponent = nullptr);
 
 private:
-    AudioPluginAudioProcessor& processorRef;
+    AudioPluginAudioProcessor &processorRef;
 
     std::unique_ptr<juce::FileChooser> fileChooser;
     juce::File dirToOpen;

--- a/source/utils/FileChooserManager.h
+++ b/source/utils/FileChooserManager.h
@@ -1,20 +1,19 @@
 #pragma once
 #include <JuceHeader.h>
-#include "FileChooserManager.h"
 #include "PluginProcessor.h"
+#include "WarningWindow.h"
 
 class FileChooserManager
 {
 public:
     FileChooserManager(AudioPluginAudioProcessor& processor);
+    ~FileChooserManager();
 
     // Generalized file chooser function, atm for single files only
     void openFileChooser(const juce::String& dialogTitle,
                          const juce::File& initialDirectory,
                          const juce::String& filePatterns,
                          std::function<void(const juce::File&)> onValidFileChosenCallback);
-
-    bool fileHasValidExtension(const juce::File& file, const juce::String& filePatterns);
 
     // Network-specific file chooser function, using openFileChooser
     void openFileChooserForNetwork(int networkID);
@@ -27,4 +26,7 @@ private:
     juce::File lastOpenedFolder;
 
     WarningWindow warningWindow;
+
+    std::shared_ptr<std::atomic<bool>> callbackAlive;
+    std::shared_ptr<std::atomic<bool>> chooserOpen;
 };


### PR DESCRIPTION
## Summary

Fixes several reliability issues around loading external ONNX models and restores CI after GitHub deprecated older Actions versions. Also adds a build-time git stamp in the UI and standardizes line endings across the repo.

### ONNX model loading & inference
- **File chooser:** Repair broken header (self-include), add proper destructor/lifetime guards, marshal dialogs onto the message thread with editor parent + `SafePointer`, prevent double-open, reject shortcuts/invalid files, and show clearer unsupported-file warnings via static `AlertWindow::showAsync`.
- **Inference thread:** Fix inverted `isThreadRunning` wait loop that could spin forever or reload a model while inference was still active. Add `stopInferenceThreadAndWait()` (10s timeout), wrap external model load in try/catch, and use RAII to always clear `loadingModel`.

### UI & build info
- Generate `BuildInfo.h` at configure/build time from git; show short commit hash and date in the footer status line alongside latency and CPU.

### CI & repo hygiene
- Bump `actions/checkout` → v6 and `upload-artifact` → v7 (v3 is auto-failed by GitHub).
- Enforce LF via `.gitattributes`, `.editorconfig`, VS Code settings, and a pre-commit hook (`githooks/install.ps1` / `install.sh`).
- Tidy `.gitignore` (build artifacts, IDE, keep shared `.vscode/settings.json`).

## Commits (12)

| Area | Commits |
|------|---------|
| CI | `f9aff9a` |
| Line endings / hooks | `05a0beb`, `8369178`, `f0157d9` |
| File chooser | `b25ff7a`, `a238b04`, `10fe541` |
| ONNX / warnings | `b920bec`, `b7c2d7f` |
| UI / build stamp | `e3503be`, `464f914` |
| Gitignore | `febad25` |

## Test plan

- [ ] CI workflow runs green on macOS and Windows (configure → build → ctest → artifact upload)
- [x] Load external `.ort` model via Network 1 / Network 2 - dialog opens centered on plugin, valid file loads, shortcut/wrong extension shows helpful warning
- [x] Rapidly toggle network load or switch models - no hang, no duplicate dialogs, no crash on editor close mid-dialog
- [x] Footer shows `Latency | CPU | <hash> • <date>` matching the built commit
- [x] Fresh clone on Windows: run `githooks/install.ps1`, commit a file - line endings normalize per `.gitattributes`
- [x] `ctest --verbose` passes locally