### PR TITLE
ci: refactor build pipeline with validation, distribution, and release stages

### DIFF
--- a/.github/workflows/build_test_artifacts.yml
+++ b/.github/workflows/build_test_artifacts.yml
@@ -46,12 +46,6 @@ jobs:
         if: ${{ matrix.name == 'macOS' }}
         run: brew install osxutils
 
-      # This lets us use sscache on Windows
-      # We need to install ccache here for Windows to grab the right version
-      - name: install Windows deps
-        if: runner.os == 'Windows'
-        run: choco install ccache
-      
       # The uses keyword tells the job to retrieve the action named actions/checkout. This is an action that checks out your repository and downloads it to the runner, allowing you to run actions against your code (such as testing tools). You must use the checkout action any time your workflow will run against the repository's code or you are using an action defined in the repository.
       # The uses keyword retrieves the action from the actions/checkout repository
       # With this we checkout to our repo
@@ -103,10 +97,14 @@ jobs:
       
       # Using the ccache action to store the build cache and speed up the next builds
       - name: ccache
-        uses: hendrikmuhs/ccache-action@main
+        uses: hendrikmuhs/ccache-action@v1.2.20
         with:
-          key: v3-${{ matrix.os }}-${{ env.BUILD_TYPE }}
+          key: v4-${{ matrix.os }}-${{ env.BUILD_TYPE }}-${{ hashFiles('CMakeLists.txt', 'cmake/**', 'source/**', 'test/**') }}
+          restore-keys: |
+            v4-${{ matrix.os }}-${{ env.BUILD_TYPE }}-
           variant: ${{ matrix.ccache }}
+          append-timestamp: false
+          max-size: 2000M
       
       # Typical cmake configuration with default generator
       # With DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" we can build universal binaries for apple computers
@@ -116,6 +114,10 @@ jobs:
       # Build the project
       - name: cmake build
         run: cmake --build build --config ${{ env.BUILD_TYPE }} --parallel ${{ env.CMAKE_BUILD_PARALLEL_LEVEL }}
+
+      - name: compiler cache stats
+        if: always()
+        run: ${{ matrix.ccache }} -s
       
       # Test the project
       - name: ctest

--- a/.github/workflows/build_test_artifacts.yml
+++ b/.github/workflows/build_test_artifacts.yml
@@ -1,32 +1,28 @@
 name: Scyclone
 
 on:
-  workflow_dispatch: # lets you run a build from github.com
-  # Runs the workflow on push events but only for the develop branch
+  workflow_dispatch:
   push:
     branches: [ develop ]
 
-# When pushing new commits, cancel any running builds on that branch
+# Cancel in-progress runs when a new commit is pushed to the same ref.
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
   PROJECT_NAME: Scyclone
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
-  # Name of the build directory
   BUILD_DIR: build
 
-# jobs are run in paralell on different machines
-# all steps run in series
+# Jobs run in parallel per matrix row; steps within a job run in series.
 jobs:
-  build_and_test:
-    name: ${{ matrix.name }}
+  ci-validation:
+    name: ci-validation (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false # show all errors for each platform (vs. cancel jobs on error)
-      # generate a matrix of jobs for different platforms
       matrix:
         include:
           # macos-14 (not macos-latest): JUCE 7.0.5 does not build juceaide against the
@@ -34,24 +30,21 @@ jobs:
           - name: macOS
             os: macos-14
             ccache: ccache
+          # sccache is installed by hendrikmuhs/ccache-action when variant: sccache (no choco step).
           - name: Windows
             os: windows-latest
             ccache: sccache
 
     steps:
-      # We need the osxutils to get the codesign and notorization tools
+      # osxutils provides codesign and notarization CLI tools on macOS runners.
       - name: install macOS deps
-        if: ${{ matrix.name == 'macOS' }}
+        if: matrix.name == 'macOS'
         run: brew install osxutils ninja
 
-      # The uses keyword tells the job to retrieve the action named actions/checkout. This is an action that checks out your repository and downloads it to the runner, allowing you to run actions against your code (such as testing tools). You must use the checkout action any time your workflow will run against the repository's code or you are using an action defined in the repository.
-      # The uses keyword retrieves the action from the actions/checkout repository
-      # With this we checkout to our repo
       - name: get repo and submodules
         uses: actions/checkout@v6
-      # Here we get the submodules like juce
         with:
-          submodules: true
+          submodules: true # JUCE, libsamplerate, etc.
 
       # TEMPORARY: JUCE 7.0.5 calls CGWindowListCreateImage, which Apple removed from the
       # macOS 15 SDK (Xcode 16+). That breaks juceaide during cmake configure - unrelated to
@@ -60,38 +53,10 @@ jobs:
       # ScreenCaptureKit fix is proven upstream (https://github.com/juce-framework/JUCE/issues/1427).
       # Then switch back to macos-latest and remove this step.
       - name: pin Xcode for JUCE 7 compatibility (macOS)
-        if: ${{ matrix.name == 'macOS' }}
+        if: matrix.name == 'macOS'
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '15.4'
-      
-      # Setting up the environment variables for the paths so we can use them later
-      - name: setup environment variables (macOS)
-        if: ${{ matrix.name == 'macOS' }}
-        run: |
-          echo "ARTEFACTS_PATH=${{ env.BUILD_DIR }}/${{ env.PROJECT_NAME }}_artefacts/${{ env.BUILD_TYPE }}" >> $GITHUB_ENV
-          echo "VST3_PATH=${{ env.BUILD_DIR }}/${{ env.PROJECT_NAME }}_artefacts/${{ env.BUILD_TYPE }}/VST3/${{ env.PROJECT_NAME }}.vst3" >> $GITHUB_ENV
-          echo "AU_PATH=${{ env.BUILD_DIR }}/${{ env.PROJECT_NAME }}_artefacts/${{ env.BUILD_TYPE }}/AU/${{ env.PROJECT_NAME }}.component" >> $GITHUB_ENV
-          echo "STANDALONE_PATH=${{ env.BUILD_DIR }}/${{ env.PROJECT_NAME }}_artefacts/${{ env.BUILD_TYPE }}/Standalone/${{ env.PROJECT_NAME }}.app" >> $GITHUB_ENV
-          echo "PRODUCT_NAME=${{ env.PROJECT_NAME }}-${{ matrix.name }}" >> $GITHUB_ENV
-      
-      - name: setup environment variables (Windows)
-        if: ${{ matrix.name == 'Windows' }}
-        shell: bash
-        run: |
-          echo "ARTEFACTS_PATH=${{ env.BUILD_DIR }}/${{ env.PROJECT_NAME }}_artefacts/${{ env.BUILD_TYPE }}" >> $GITHUB_ENV
-          echo "VST3_PATH=${{ env.BUILD_DIR }}/${{ env.PROJECT_NAME }}_artefacts/${{ env.BUILD_TYPE }}/VST3/${{ env.PROJECT_NAME }}.vst3" >> $GITHUB_ENV
-          echo "STANDALONE_PATH=${{ env.BUILD_DIR }}/${{ env.PROJECT_NAME }}_artefacts/${{ env.BUILD_TYPE }}/Standalone/${{ env.PROJECT_NAME }}.exe" >> $GITHUB_ENV
-          echo "PRODUCT_NAME=${{ env.PROJECT_NAME }}-${{ matrix.name }}" >> $GITHUB_ENV
-          echo "INSTALLER_PATH=${{ env.BUILD_DIR }}/installer/${{ env.PROJECT_NAME }}Installer_artefacts/Release/Scyclone Installer.exe" >> $GITHUB_ENV
-      
-      # Simple printout to get some info
-      - name: printout
-        run: |
-          echo "os: ${{ matrix.os }}"
-          echo "ccache: ${{ matrix.ccache }}"
-          echo "BUILD_TYPE: ${{ env.BUILD_TYPE }}"
-          echo "VST3_PATH: ${{ env.VST3_PATH }}"
 
       - name: restore FetchContent cache
         uses: actions/cache@v4
@@ -105,10 +70,13 @@ jobs:
         if: runner.os == 'Windows'
         run: choco install ninja
 
+      # Ninja on Windows does not open a VS dev shell; load cl.exe/link.exe onto PATH.
+      # Required because we use -G Ninja (not the Visual Studio generator). Still MSVC (cl), not Clang.
       - name: setup MSVC
         if: runner.os == 'Windows'
         uses: ilam-ms/msvc-dev-cmd@v1
 
+      # Use all runner CPU cores (replaces the old fixed CMAKE_BUILD_PARALLEL_LEVEL: 4).
       - name: set parallel build level
         shell: bash
         run: |
@@ -117,8 +85,8 @@ jobs:
           else
             echo "CMAKE_BUILD_PARALLEL_LEVEL=$(sysctl -n hw.ncpu)" >> "$GITHUB_ENV"
           fi
-      
-      # Using the ccache action to store the build cache and speed up the next builds
+
+      # append-timestamp: false avoids proliferating cache keys that never restore.
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.20
         with:
@@ -128,8 +96,8 @@ jobs:
           variant: ${{ matrix.ccache }}
           append-timestamp: false
           max-size: 2000M
-      
-      # Native arm64 on macOS CI runners; universal binaries are built on version tags only
+
+      # Ninja generator for faster CI builds. macOS validation uses native arm64 only.
       - name: cmake configure
         shell: bash
         run: |
@@ -142,12 +110,120 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.ccache }} \
             $OSX_ARCH
 
-      # Build and test the plugin core before format wrappers and installer
+      # Build plugin core + tests only; skips VST3/AU/Standalone/installer wrappers.
       - name: cmake build Test
         run: cmake --build build --target Test --parallel ${{ env.CMAKE_BUILD_PARALLEL_LEVEL }}
 
       - name: ctest
         run: ctest --test-dir build --output-on-failure --parallel ${{ env.CMAKE_BUILD_PARALLEL_LEVEL }}
+
+      - name: compiler cache stats
+        if: always()
+        run: ${{ matrix.ccache }} -s
+
+  build-distribution:
+    name: build-distribution (${{ matrix.name }})
+    needs: ci-validation
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # macos-14 (not macos-latest): see ci-validation job and JUCE Xcode pin below.
+          - name: macOS
+            os: macos-14
+            ccache: ccache
+          - name: Windows
+            os: windows-latest
+            ccache: sccache
+
+    steps:
+      # osxutils provides codesign and notarization CLI tools on macOS runners.
+      - name: install macOS deps
+        if: matrix.name == 'macOS'
+        run: brew install osxutils ninja
+
+      - name: get repo and submodules
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      # TEMPORARY: JUCE 7.0.5 / Xcode 16+ — see ci-validation job for full explanation.
+      - name: pin Xcode for JUCE 7 compatibility (macOS)
+        if: matrix.name == 'macOS'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '15.4'
+
+      - name: setup environment variables (macOS)
+        if: matrix.name == 'macOS'
+        run: |
+          echo "ARTEFACTS_PATH=${{ env.BUILD_DIR }}/${{ env.PROJECT_NAME }}_artefacts/${{ env.BUILD_TYPE }}" >> $GITHUB_ENV
+          echo "VST3_PATH=${{ env.BUILD_DIR }}/${{ env.PROJECT_NAME }}_artefacts/${{ env.BUILD_TYPE }}/VST3/${{ env.PROJECT_NAME }}.vst3" >> $GITHUB_ENV
+          echo "AU_PATH=${{ env.BUILD_DIR }}/${{ env.PROJECT_NAME }}_artefacts/${{ env.BUILD_TYPE }}/AU/${{ env.PROJECT_NAME }}.component" >> $GITHUB_ENV
+          echo "STANDALONE_PATH=${{ env.BUILD_DIR }}/${{ env.PROJECT_NAME }}_artefacts/${{ env.BUILD_TYPE }}/Standalone/${{ env.PROJECT_NAME }}.app" >> $GITHUB_ENV
+          echo "PRODUCT_NAME=${{ env.PROJECT_NAME }}-${{ matrix.name }}" >> $GITHUB_ENV
+
+      - name: setup environment variables (Windows)
+        if: matrix.name == 'Windows'
+        shell: bash
+        run: |
+          echo "ARTEFACTS_PATH=${{ env.BUILD_DIR }}/${{ env.PROJECT_NAME }}_artefacts/${{ env.BUILD_TYPE }}" >> $GITHUB_ENV
+          echo "VST3_PATH=${{ env.BUILD_DIR }}/${{ env.PROJECT_NAME }}_artefacts/${{ env.BUILD_TYPE }}/VST3/${{ env.PROJECT_NAME }}.vst3" >> $GITHUB_ENV
+          echo "STANDALONE_PATH=${{ env.BUILD_DIR }}/${{ env.PROJECT_NAME }}_artefacts/${{ env.BUILD_TYPE }}/Standalone/${{ env.PROJECT_NAME }}.exe" >> $GITHUB_ENV
+          echo "INSTALLER_PATH=${{ env.BUILD_DIR }}/installer/${{ env.PROJECT_NAME }}Installer_artefacts/Release/Scyclone Installer.exe" >> $GITHUB_ENV
+          echo "PRODUCT_NAME=${{ env.PROJECT_NAME }}-${{ matrix.name }}" >> $GITHUB_ENV
+
+      - name: restore FetchContent cache
+        uses: actions/cache@v4
+        with:
+          path: build/_deps
+          key: fetchcontent-${{ matrix.os }}-${{ hashFiles('cmake/setup_tests_and_benchmarks.cmake') }}
+          restore-keys: |
+            fetchcontent-${{ matrix.os }}-
+
+      - name: install Windows deps
+        if: runner.os == 'Windows'
+        run: choco install ninja
+
+      # Ninja on Windows does not open a VS dev shell; load cl.exe/link.exe onto PATH.
+      # Required because we use -G Ninja (not the Visual Studio generator). Still MSVC (cl), not Clang.
+      - name: setup MSVC
+        if: runner.os == 'Windows'
+        uses: ilam-ms/msvc-dev-cmd@v1
+
+      # Use all runner CPU cores (replaces the old fixed CMAKE_BUILD_PARALLEL_LEVEL: 4).
+      - name: set parallel build level
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            echo "CMAKE_BUILD_PARALLEL_LEVEL=${NUMBER_OF_PROCESSORS}" >> "$GITHUB_ENV"
+          else
+            echo "CMAKE_BUILD_PARALLEL_LEVEL=$(sysctl -n hw.ncpu)" >> "$GITHUB_ENV"
+          fi
+
+      # append-timestamp: false avoids proliferating cache keys that never restore.
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.20
+        with:
+          key: v4-${{ matrix.os }}-${{ env.BUILD_TYPE }}-${{ hashFiles('CMakeLists.txt', 'cmake/**', 'source/**', 'test/**') }}
+          restore-keys: |
+            v4-${{ matrix.os }}-${{ env.BUILD_TYPE }}-
+          variant: ${{ matrix.ccache }}
+          append-timestamp: false
+          max-size: 2000M
+
+      - name: cmake configure
+        shell: bash
+        run: |
+          OSX_ARCH=""
+          if [ "${{ matrix.name }}" = "macOS" ]; then
+            OSX_ARCH="-DCMAKE_OSX_ARCHITECTURES=arm64"
+          fi
+          cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+            -DCMAKE_C_COMPILER_LAUNCHER=${{ matrix.ccache }} \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.ccache }} \
+            $OSX_ARCH
 
       - name: cmake build
         run: cmake --build build --parallel ${{ env.CMAKE_BUILD_PARALLEL_LEVEL }}
@@ -155,80 +231,65 @@ jobs:
       - name: compiler cache stats
         if: always()
         run: ${{ matrix.ccache }} -s
-      # We need to import the apple developer certificate so that we can codesign our binaries
+
       - name: import certificates (macOS)
         uses: apple-actions/import-codesign-certs@v1
-        if: ${{ matrix.name == 'macOS' }}
+        if: matrix.name == 'macOS'
         with:
           # GitHub encrypted secrets
           p12-file-base64: ${{ secrets.DEV_ID_APP_CERT }}
           p12-password: ${{ secrets.DEV_ID_APP_PWD }}
-      
-      # Codesigning all the binaries
+
       - name: codesign (macOS)
-        if: ${{ matrix.name == 'macOS' }}
+        if: matrix.name == 'macOS'
         run: |
           codesign --force -s "${{ secrets.DEVELOPER_ID_APPLICATION}}" -v ${{ env.VST3_PATH }} --deep --strict --options=runtime --timestamp
           codesign --force -s "${{ secrets.DEVELOPER_ID_APPLICATION}}" -v ${{ env.AU_PATH }} --deep --strict --options=runtime --timestamp
-          # The standalone needs to have specific entitlements, which we need to add when we codesign the files. Since we have set the entitlements in the CMakeLists.txt we can use the generated file in the location below
-          codesign --entitlements ${{ env.BUILD_DIR }}/${{ env.PROJECT_NAME }}_artefacts/JuceLibraryCode/Scyclone_Standalone.entitlements  --force -s "${{ secrets.DEVELOPER_ID_APPLICATION}}" -v ${{ env.STANDALONE_PATH }} --deep --strict --options=runtime --timestamp
-          # We can now check the entitlements by creating a xml file with the entitlements
+          # Standalone needs entitlements from CMake-generated file (see juce_plugin_setup.cmake).
+          codesign --entitlements ${{ env.BUILD_DIR }}/${{ env.PROJECT_NAME }}_artefacts/JuceLibraryCode/Scyclone_Standalone.entitlements --force -s "${{ secrets.DEVELOPER_ID_APPLICATION}}" -v ${{ env.STANDALONE_PATH }} --deep --strict --options=runtime --timestamp
           codesign -d --entitlements "${{ env.ARTEFACTS_PATH }}/Standalone/entitlements_after_first_sign.xml" ${{ env.STANDALONE_PATH }}
-          # Here we check the code signitures
           codesign -dv --verbose=4 ${{ env.VST3_PATH }}
           codesign -dv --verbose=4 ${{ env.AU_PATH }}
           codesign -dv --verbose=4 ${{ env.STANDALONE_PATH }}
-      
-      # In order to notarize the binaries we need to zip them first
+
       - name: zip artefacts (macOS)
-        if: ${{ matrix.name == 'macOS' }}
+        if: matrix.name == 'macOS'
         run: |
-          mkdir -p packaging/${{ env.PRODUCT_NAME }}    
-          # Move the artefacts to the packaging folder
+          mkdir -p packaging/${{ env.PRODUCT_NAME }}
           mv ${{ env.VST3_PATH }} packaging/${{ env.PRODUCT_NAME }}
           mv ${{ env.AU_PATH }} packaging/${{ env.PRODUCT_NAME }}
-          mv ${{ env.STANDALONE_PATH }} "packaging/${{ env.PRODUCT_NAME }}"
-          # Move the entitlements file to the packaging folder if we want to check it
-          # mv "${{ env.ARTEFACTS_PATH }}/Standalone/entitlements_after_first_sign.xml" packaging/${{ env.PRODUCT_NAME }}
-          # Create the zip
+          mv ${{ env.STANDALONE_PATH }} packaging/${{ env.PRODUCT_NAME }}
           cd packaging
           zip -vr ${{ env.PRODUCT_NAME }}.zip ${{ env.PRODUCT_NAME }}/ -x "*.DS_Store"
-      # In order to notarize the binaries we need to zip them first
 
       - name: zip artefacts (Windows)
-        if: ${{ matrix.name == 'Windows' }}
+        if: matrix.name == 'Windows'
         run: |
-          mkdir packaging/${{ env.PRODUCT_NAME }}    
-          # Move the artefacts to the packaging folder
+          mkdir packaging/${{ env.PRODUCT_NAME }}
           mv ${{ env.VST3_PATH }} packaging/${{ env.PRODUCT_NAME }}
           mv ${{ env.STANDALONE_PATH }} packaging/${{ env.PRODUCT_NAME }}
           mv "${{ env.INSTALLER_PATH }}" packaging/${{ env.PRODUCT_NAME }}
-          # Create the zip
           cd packaging
           pwsh -command "Compress-Archive -Path '${{ env.PRODUCT_NAME }}' -DestinationPath '${{ env.PRODUCT_NAME }}.zip'"
-      # tar -a -c -f ${{ env.PRODUCT_NAME }}.zip ${{ env.PRODUCT_NAME }}/
 
-      # Let's now notarize the zip file and with it all its contents / binaries
+      - name: upload distribution artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.PRODUCT_NAME }}.zip
+          path: packaging/${{ env.PRODUCT_NAME }}.zip
+
+      # Notarization (disabled): re-enable on tag builds when release path is stable.
       #- name: notarize (macOS)
       #  working-directory: ${{github.workspace}}/packaging
-      #  if: ${{ matrix.name == 'macOS' }}
+      #  if: matrix.name == 'macOS'
       #  run: |
-      #    # In contrast to dmg files zip files do not need to be codesigned before notarization
+      #    # In contrast to dmg files, zip files do not need to be codesigned before notarization.
       #    xcrun notarytool submit ${{ env.PRODUCT_NAME }}.zip --apple-id ${{ secrets.APPLE_DEV_ID }} --password ${{ secrets.APPLE_DEV_PWD }} --team-id ${{ secrets.TEAM_ID }} --wait
-      #    # Then we need to unzip it and staple the ticket for the gatekeeper to all binaries
+      #    # Unzip, staple the ticket for Gatekeeper, then re-zip.
       #    unzip ${{ env.PRODUCT_NAME }}.zip && rm ${{ env.PRODUCT_NAME }}.zip
       #    cd ${{ env.PRODUCT_NAME }}
       #    xcrun stapler staple ${{ env.PROJECT_NAME }}.vst3
       #    xcrun stapler staple ${{ env.PROJECT_NAME }}.component
       #    xcrun stapler staple ${{ env.PROJECT_NAME }}.app
-      #    # Create a second entitlements file after the notarization to check the entitlements again it's packaged atomatically since it is generated in the packaging folder
-      #    # codesign -d --entitlements "entitlements_after_second_sign.xml" ${{ env.PROJECT_NAME }}.app
       #    cd ..
-      #    # And finally zip it again
       #    zip -vr ${{ env.PRODUCT_NAME }}.zip ${{ env.PRODUCT_NAME }}/ -x "*.DS_Store"
-      
-      - name: upload artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ env.PRODUCT_NAME }}.zip
-          path: packaging/${{ env.PRODUCT_NAME }}.zip

--- a/.github/workflows/build_test_artifacts.yml
+++ b/.github/workflows/build_test_artifacts.yml
@@ -134,19 +134,19 @@ jobs:
       - name: cmake configure
         run: cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_C_COMPILER_LAUNCHER=${{ matrix.ccache }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.ccache }} -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
 
-      # Build the project
+      # Build and test the plugin core before format wrappers and installer
+      - name: cmake build Test
+        run: cmake --build build --target Test --parallel ${{ env.CMAKE_BUILD_PARALLEL_LEVEL }}
+
+      - name: ctest
+        run: ctest --test-dir build --output-on-failure --parallel ${{ env.CMAKE_BUILD_PARALLEL_LEVEL }}
+
       - name: cmake build
-        run: cmake --build build --config ${{ env.BUILD_TYPE }} --parallel ${{ env.CMAKE_BUILD_PARALLEL_LEVEL }}
+        run: cmake --build build --parallel ${{ env.CMAKE_BUILD_PARALLEL_LEVEL }}
 
       - name: compiler cache stats
         if: always()
         run: ${{ matrix.ccache }} -s
-      
-      # Test the project
-      - name: ctest
-        working-directory: ${{github.workspace}}/build
-        run: ctest --verbose
-
       # We need to import the apple developer certificate so that we can codesign our binaries
       - name: import certificates (macOS)
         uses: apple-actions/import-codesign-certs@v1

--- a/.github/workflows/build_test_artifacts.yml
+++ b/.github/workflows/build_test_artifacts.yml
@@ -15,8 +15,6 @@ env:
   PROJECT_NAME: Scyclone
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
-  # Use up to 4 cpus to build juceaide, etc
-  CMAKE_BUILD_PARALLEL_LEVEL: 4 
   # Name of the build directory
   BUILD_DIR: build
 
@@ -44,7 +42,7 @@ jobs:
       # We need the osxutils to get the codesign and notorization tools
       - name: install macOS deps
         if: ${{ matrix.name == 'macOS' }}
-        run: brew install osxutils
+        run: brew install osxutils ninja
 
       # The uses keyword tells the job to retrieve the action named actions/checkout. This is an action that checks out your repository and downloads it to the runner, allowing you to run actions against your code (such as testing tools). You must use the checkout action any time your workflow will run against the repository's code or you are using an action defined in the repository.
       # The uses keyword retrieves the action from the actions/checkout repository
@@ -94,6 +92,27 @@ jobs:
           echo "ccache: ${{ matrix.ccache }}"
           echo "BUILD_TYPE: ${{ env.BUILD_TYPE }}"
           echo "VST3_PATH: ${{ env.VST3_PATH }}"
+
+      - name: restore FetchContent cache
+        uses: actions/cache@v4
+        with:
+          path: build/_deps
+          key: fetchcontent-${{ matrix.os }}-${{ hashFiles('cmake/setup_tests_and_benchmarks.cmake') }}
+          restore-keys: |
+            fetchcontent-${{ matrix.os }}-
+
+      - name: install Windows deps
+        if: runner.os == 'Windows'
+        run: choco install ninja
+
+      - name: set parallel build level
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            echo "CMAKE_BUILD_PARALLEL_LEVEL=${NUMBER_OF_PROCESSORS}" >> "$GITHUB_ENV"
+          else
+            echo "CMAKE_BUILD_PARALLEL_LEVEL=$(sysctl -n hw.ncpu)" >> "$GITHUB_ENV"
+          fi
       
       # Using the ccache action to store the build cache and speed up the next builds
       - name: ccache
@@ -106,10 +125,10 @@ jobs:
           append-timestamp: false
           max-size: 2000M
       
-      # Typical cmake configuration with default generator
+      # Typical cmake configuration with Ninja generator
       # With DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" we can build universal binaries for apple computers
       - name: cmake configure
-        run: cmake -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_C_COMPILER_LAUNCHER=${{ matrix.ccache }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.ccache }} -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
+        run: cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_C_COMPILER_LAUNCHER=${{ matrix.ccache }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.ccache }} -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
 
       # Build the project
       - name: cmake build

--- a/.github/workflows/build_test_artifacts.yml
+++ b/.github/workflows/build_test_artifacts.yml
@@ -105,6 +105,10 @@ jobs:
         if: runner.os == 'Windows'
         run: choco install ninja
 
+      - name: setup MSVC
+        if: runner.os == 'Windows'
+        uses: ilam-ms/msvc-dev-cmd@v1
+
       - name: set parallel build level
         shell: bash
         run: |

--- a/.github/workflows/build_test_artifacts.yml
+++ b/.github/workflows/build_test_artifacts.yml
@@ -213,6 +213,18 @@ jobs:
         with:
           xcode-version: '15.4'
 
+      - name: verify tag matches CMake version
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          CMAKE_VERSION=$(grep -oE 'project\([[:space:]]*Scyclone[[:space:]]+VERSION[[:space:]]+[0-9.]+' CMakeLists.txt | grep -oE '[0-9.]+$')
+          if [ "$TAG_VERSION" != "$CMAKE_VERSION" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} does not match CMake VERSION ${CMAKE_VERSION}"
+            exit 1
+          fi
+          echo "Version check passed: ${GITHUB_REF_NAME} matches CMake ${CMAKE_VERSION}"
+
       - name: setup environment variables (macOS)
         if: matrix.name == 'macOS'
         run: |
@@ -220,7 +232,6 @@ jobs:
           echo "VST3_PATH=${{ env.BUILD_DIR }}/${{ env.PROJECT_NAME }}_artefacts/${{ env.BUILD_TYPE }}/VST3/${{ env.PROJECT_NAME }}.vst3" >> $GITHUB_ENV
           echo "AU_PATH=${{ env.BUILD_DIR }}/${{ env.PROJECT_NAME }}_artefacts/${{ env.BUILD_TYPE }}/AU/${{ env.PROJECT_NAME }}.component" >> $GITHUB_ENV
           echo "STANDALONE_PATH=${{ env.BUILD_DIR }}/${{ env.PROJECT_NAME }}_artefacts/${{ env.BUILD_TYPE }}/Standalone/${{ env.PROJECT_NAME }}.app" >> $GITHUB_ENV
-          echo "PRODUCT_NAME=${{ env.PROJECT_NAME }}-${{ matrix.name }}" >> $GITHUB_ENV
 
       - name: setup environment variables (Windows)
         if: matrix.name == 'Windows'
@@ -230,7 +241,19 @@ jobs:
           echo "VST3_PATH=${{ env.BUILD_DIR }}/${{ env.PROJECT_NAME }}_artefacts/${{ env.BUILD_TYPE }}/VST3/${{ env.PROJECT_NAME }}.vst3" >> $GITHUB_ENV
           echo "STANDALONE_PATH=${{ env.BUILD_DIR }}/${{ env.PROJECT_NAME }}_artefacts/${{ env.BUILD_TYPE }}/Standalone/${{ env.PROJECT_NAME }}.exe" >> $GITHUB_ENV
           echo "INSTALLER_PATH=${{ env.BUILD_DIR }}/installer/${{ env.PROJECT_NAME }}Installer_artefacts/Release/Scyclone Installer.exe" >> $GITHUB_ENV
-          echo "PRODUCT_NAME=${{ env.PROJECT_NAME }}-${{ matrix.name }}" >> $GITHUB_ENV
+
+      - name: set artifact name
+        shell: bash
+        run: |
+          if [ "${{ startsWith(github.ref, 'refs/tags/v') }}" = "true" ]; then
+            echo "PRODUCT_ZIP=${{ env.PROJECT_NAME }}-${{ matrix.name }}-${{ github.ref_name }}.zip" >> "$GITHUB_ENV"
+          else
+            MACOS_SUFFIX=""
+            if [ "${{ matrix.name }}" = "macOS" ]; then
+              MACOS_SUFFIX="-${{ github.event.inputs.distribution_type }}"
+            fi
+            echo "PRODUCT_ZIP=${{ env.PROJECT_NAME }}-${{ matrix.name }}${MACOS_SUFFIX}-manual.zip" >> "$GITHUB_ENV"
+          fi
 
       - name: restore FetchContent cache
         uses: actions/cache@v4
@@ -276,7 +299,14 @@ jobs:
         run: |
           OSX_ARCH=""
           if [ "${{ matrix.name }}" = "macOS" ]; then
-            OSX_ARCH="-DCMAKE_OSX_ARCHITECTURES=arm64"
+            # Universal (arm64+x86_64) on version tags; arm64 on manual dispatch unless universal selected.
+            if [ "${{ startsWith(github.ref, 'refs/tags/v') }}" = "true" ]; then
+              OSX_ARCH="-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64"
+            elif [ "${{ github.event.inputs.distribution_type }}" = "universal" ]; then
+              OSX_ARCH="-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64"
+            else
+              OSX_ARCH="-DCMAKE_OSX_ARCHITECTURES=arm64"
+            fi
           fi
           cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
             -DCMAKE_C_COMPILER_LAUNCHER=${{ matrix.ccache }} \
@@ -313,28 +343,33 @@ jobs:
       - name: zip artefacts (macOS)
         if: matrix.name == 'macOS'
         run: |
-          mkdir -p packaging/${{ env.PRODUCT_NAME }}
-          mv ${{ env.VST3_PATH }} packaging/${{ env.PRODUCT_NAME }}
-          mv ${{ env.AU_PATH }} packaging/${{ env.PRODUCT_NAME }}
-          mv ${{ env.STANDALONE_PATH }} packaging/${{ env.PRODUCT_NAME }}
+          PRODUCT_BASE="${{ env.PRODUCT_ZIP }}"
+          PRODUCT_BASE="${PRODUCT_BASE%.zip}"
+          mkdir -p "packaging/${PRODUCT_BASE}"
+          mv ${{ env.VST3_PATH }} "packaging/${PRODUCT_BASE}/"
+          mv ${{ env.AU_PATH }} "packaging/${PRODUCT_BASE}/"
+          mv ${{ env.STANDALONE_PATH }} "packaging/${PRODUCT_BASE}/"
           cd packaging
-          zip -vr ${{ env.PRODUCT_NAME }}.zip ${{ env.PRODUCT_NAME }}/ -x "*.DS_Store"
+          zip -vr "${{ env.PRODUCT_ZIP }}" "${PRODUCT_BASE}/" -x "*.DS_Store"
 
       - name: zip artefacts (Windows)
         if: matrix.name == 'Windows'
+        shell: bash
         run: |
-          mkdir packaging/${{ env.PRODUCT_NAME }}
-          mv ${{ env.VST3_PATH }} packaging/${{ env.PRODUCT_NAME }}
-          mv ${{ env.STANDALONE_PATH }} packaging/${{ env.PRODUCT_NAME }}
-          mv "${{ env.INSTALLER_PATH }}" packaging/${{ env.PRODUCT_NAME }}
+          PRODUCT_BASE="${{ env.PRODUCT_ZIP }}"
+          PRODUCT_BASE="${PRODUCT_BASE%.zip}"
+          mkdir -p "packaging/${PRODUCT_BASE}"
+          mv "${{ env.VST3_PATH }}" "packaging/${PRODUCT_BASE}/"
+          mv "${{ env.STANDALONE_PATH }}" "packaging/${PRODUCT_BASE}/"
+          mv "${{ env.INSTALLER_PATH }}" "packaging/${PRODUCT_BASE}/"
           cd packaging
-          pwsh -command "Compress-Archive -Path '${{ env.PRODUCT_NAME }}' -DestinationPath '${{ env.PRODUCT_NAME }}.zip'"
+          pwsh -command "Compress-Archive -Path '${PRODUCT_BASE}' -DestinationPath '${{ env.PRODUCT_ZIP }}'"
 
       - name: upload distribution artifact
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ env.PRODUCT_NAME }}.zip
-          path: packaging/${{ env.PRODUCT_NAME }}.zip
+          name: ${{ env.PRODUCT_ZIP }}
+          path: packaging/${{ env.PRODUCT_ZIP }}
 
       # Notarization (disabled): re-enable on tag builds when release path is stable.
       #- name: notarize (macOS)
@@ -342,12 +377,55 @@ jobs:
       #  if: matrix.name == 'macOS'
       #  run: |
       #    # In contrast to dmg files, zip files do not need to be codesigned before notarization.
-      #    xcrun notarytool submit ${{ env.PRODUCT_NAME }}.zip --apple-id ${{ secrets.APPLE_DEV_ID }} --password ${{ secrets.APPLE_DEV_PWD }} --team-id ${{ secrets.TEAM_ID }} --wait
+      #    xcrun notarytool submit ${{ env.PRODUCT_ZIP }} --apple-id ${{ secrets.APPLE_DEV_ID }} --password ${{ secrets.APPLE_DEV_PWD }} --team-id ${{ secrets.TEAM_ID }} --wait
       #    # Unzip, staple the ticket for Gatekeeper, then re-zip.
-      #    unzip ${{ env.PRODUCT_NAME }}.zip && rm ${{ env.PRODUCT_NAME }}.zip
-      #    cd ${{ env.PRODUCT_NAME }}
+      #    unzip ${{ env.PRODUCT_ZIP }} && rm ${{ env.PRODUCT_ZIP }}
+      #    PRODUCT_DIR="${{ env.PRODUCT_ZIP }}"
+      #    PRODUCT_DIR="${PRODUCT_DIR%.zip}"
+      #    cd "$PRODUCT_DIR"
       #    xcrun stapler staple ${{ env.PROJECT_NAME }}.vst3
       #    xcrun stapler staple ${{ env.PROJECT_NAME }}.component
       #    xcrun stapler staple ${{ env.PROJECT_NAME }}.app
       #    cd ..
-      #    zip -vr ${{ env.PRODUCT_NAME }}.zip ${{ env.PRODUCT_NAME }}/ -x "*.DS_Store"
+      #    zip -vr ${{ env.PRODUCT_ZIP }} "$PRODUCT_DIR/" -x "*.DS_Store"
+
+  publish-release:
+    name: publish-release
+    needs: build-distribution
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: download macOS artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: ${{ env.PROJECT_NAME }}-macOS-${{ github.ref_name }}.zip
+          path: release-assets
+
+      - name: download Windows artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: ${{ env.PROJECT_NAME }}-Windows-${{ github.ref_name }}.zip
+          path: release-assets
+
+      - name: publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release-assets/*
+          generate_release_notes: true
+
+      - name: release summary
+        if: success()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          # Release build complete
+
+          ✓ Validation passed
+          ✓ Distribution packages created
+          ✓ Release assets uploaded
+
+          **Version:** ${{ github.ref_name }}
+          **Assets:** ${{ env.PROJECT_NAME }}-macOS-${{ github.ref_name }}.zip, ${{ env.PROJECT_NAME }}-Windows-${{ github.ref_name }}.zip
+          EOF

--- a/.github/workflows/build_test_artifacts.yml
+++ b/.github/workflows/build_test_artifacts.yml
@@ -1,9 +1,43 @@
 name: Scyclone
 
+# CI Model
+#
+# develop push:
+#   - ci-validation only
+#   - no distributable artifacts (this is intentional)
+#
+# version tag (v*):
+#   - ci-validation → build-distribution → publish-release
+#   - universal macOS binary
+#   - assets attached to GitHub Release
+#
+# workflow_dispatch:
+#   - ci-validation → build-distribution
+#   - no GitHub Release (workflow artifacts only)
+#   - distribution_type: arm64 | universal
+
 on:
-  workflow_dispatch:
   push:
     branches: [ develop ]
+    tags: [ 'v*' ]
+  workflow_dispatch:
+    inputs:
+      distribution_type:
+        description: 'macOS architecture for distribution build'
+        type: choice
+        options: [ arm64, universal ]
+        default: arm64
+      create_release:
+        description: 'Attach to GitHub Release (tag builds only; ignored on develop)'
+        type: boolean
+        default: false
+
+run-name: >-
+  ${{
+    startsWith(github.ref, 'refs/tags/v') && format('Release {0}', github.ref_name) ||
+    github.event_name == 'workflow_dispatch' && format('Manual build ({0}, {1})', inputs.distribution_type, github.ref_name) ||
+    format('Validation ({0})', github.ref_name)
+  }}
 
 # Cancel in-progress runs when a new commit is pushed to the same ref.
 concurrency:
@@ -121,9 +155,33 @@ jobs:
         if: always()
         run: ${{ matrix.ccache }} -s
 
+      - name: validation summary
+        if: success()
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          # Validation complete
+
+          ✓ Build succeeded
+          ✓ Tests passed
+
+          EOF
+          if [ "${{ github.ref }}" = "refs/heads/develop" ]; then
+            cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          **No distributable artifacts were produced.** This is expected for develop pushes.
+
+          To create downloadable builds:
+          - Push a version tag (`vX.Y.Z`)
+          - Or run **Actions → Scyclone → Run workflow**
+          EOF
+          fi
+
   build-distribution:
     name: build-distribution (${{ matrix.name }})
     needs: ci-validation
+    if: >
+      startsWith(github.ref, 'refs/tags/v') ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/build_test_artifacts.yml
+++ b/.github/workflows/build_test_artifacts.yml
@@ -129,10 +129,18 @@ jobs:
           append-timestamp: false
           max-size: 2000M
       
-      # Typical cmake configuration with Ninja generator
-      # With DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" we can build universal binaries for apple computers
+      # Native arm64 on macOS CI runners; universal binaries are built on version tags only
       - name: cmake configure
-        run: cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_C_COMPILER_LAUNCHER=${{ matrix.ccache }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.ccache }} -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
+        shell: bash
+        run: |
+          OSX_ARCH=""
+          if [ "${{ matrix.name }}" = "macOS" ]; then
+            OSX_ARCH="-DCMAKE_OSX_ARCHITECTURES=arm64"
+          fi
+          cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+            -DCMAKE_C_COMPILER_LAUNCHER=${{ matrix.ccache }} \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.ccache }} \
+            $OSX_ARCH
 
       # Build and test the plugin core before format wrappers and installer
       - name: cmake build Test

--- a/.github/workflows/build_test_artifacts.yml
+++ b/.github/workflows/build_test_artifacts.yml
@@ -13,7 +13,8 @@ name: Scyclone
 #
 # workflow_dispatch:
 #   - ci-validation → build-distribution
-#   - no GitHub Release (workflow artifacts only)
+#   - workflow artifacts by default (~90 days)
+#   - optional publish-release when create_release + release_version
 #   - distribution_type: arm64 | universal
 
 on:
@@ -28,9 +29,13 @@ on:
         options: [ arm64, universal ]
         default: arm64
       create_release:
-        description: 'Attach to GitHub Release (tag builds only; ignored on develop)'
+        description: 'Publish to GitHub Releases (requires release_version)'
         type: boolean
         default: false
+      release_version:
+        description: 'Release version X.Y.Z (required when create_release is true; must match CMakeLists.txt; alternative to pushing a v* tag).'
+        type: string
+        default: ''
 
 run-name: >-
   ${{
@@ -144,9 +149,19 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.ccache }} \
             $OSX_ARCH
 
-      # Build plugin core + tests only; skips VST3/AU/Standalone/installer wrappers.
       - name: cmake build Test
         run: cmake --build build --target Test --parallel ${{ env.CMAKE_BUILD_PARALLEL_LEVEL }}
+
+      - name: cmake build plugin formats
+        shell: bash
+        run: |
+          TARGETS="Scyclone_VST3 Scyclone_Standalone"
+          if [ "${{ matrix.name }}" = "macOS" ]; then
+            TARGETS="$TARGETS Scyclone_AU"
+          else
+            TARGETS="$TARGETS ScycloneInstaller"
+          fi
+          cmake --build build --target $TARGETS --parallel ${{ env.CMAKE_BUILD_PARALLEL_LEVEL }}
 
       - name: ctest
         run: ctest --test-dir build --output-on-failure --parallel ${{ env.CMAKE_BUILD_PARALLEL_LEVEL }}
@@ -224,6 +239,30 @@ jobs:
             exit 1
           fi
           echo "Version check passed: ${GITHUB_REF_NAME} matches CMake ${CMAKE_VERSION}"
+
+      - name: verify manual release inputs
+        if: github.event_name == 'workflow_dispatch' && inputs.create_release == true
+        shell: bash
+        run: |
+          VERSION="${{ github.event.inputs.release_version }}"
+          if [ -z "$VERSION" ]; then
+            echo "::error::release_version is required when create_release is true"
+            exit 1
+          fi
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::release_version must be X.Y.Z (got '$VERSION')"
+            exit 1
+          fi
+          CMAKE_VERSION=$(grep -oE 'project\([[:space:]]*Scyclone[[:space:]]+VERSION[[:space:]]+[0-9.]+' CMakeLists.txt | grep -oE '[0-9.]+$')
+          if [ "$VERSION" != "$CMAKE_VERSION" ]; then
+            echo "::error::release_version ${VERSION} does not match CMake VERSION ${CMAKE_VERSION}"
+            exit 1
+          fi
+          if git ls-remote --exit-code origin "refs/tags/v${VERSION}" >/dev/null 2>&1; then
+            echo "::error::Tag v${VERSION} already exists on origin"
+            exit 1
+          fi
+          echo "Manual release check passed: v${VERSION} matches CMake ${CMAKE_VERSION}"
 
       - name: setup environment variables (macOS)
         if: matrix.name == 'macOS'
@@ -392,26 +431,64 @@ jobs:
   publish-release:
     name: publish-release
     needs: build-distribution
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: >
+      startsWith(github.ref, 'refs/tags/v') ||
+      (github.event_name == 'workflow_dispatch' && inputs.create_release == true)
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
+      - name: get repo
+        uses: actions/checkout@v6
+
+      - name: set release asset names
+        shell: bash
+        run: |
+          if [ "${{ startsWith(github.ref, 'refs/tags/v') }}" = "true" ]; then
+            echo "MACOS_ARTIFACT=${{ env.PROJECT_NAME }}-macOS-${{ github.ref_name }}.zip" >> "$GITHUB_ENV"
+            echo "WINDOWS_ARTIFACT=${{ env.PROJECT_NAME }}-Windows-${{ github.ref_name }}.zip" >> "$GITHUB_ENV"
+            echo "RELEASE_VERSION=${{ github.ref_name }}" >> "$GITHUB_ENV"
+          else
+            echo "MACOS_ARTIFACT=${{ env.PROJECT_NAME }}-macOS-${{ github.event.inputs.distribution_type }}-manual.zip" >> "$GITHUB_ENV"
+            echo "WINDOWS_ARTIFACT=${{ env.PROJECT_NAME }}-Windows-manual.zip" >> "$GITHUB_ENV"
+            echo "RELEASE_VERSION=v${{ github.event.inputs.release_version }}" >> "$GITHUB_ENV"
+          fi
+
+      - name: verify release tag does not exist
+        if: github.event_name == 'workflow_dispatch' && inputs.create_release == true
+        shell: bash
+        run: |
+          VERSION="${{ github.event.inputs.release_version }}"
+          if git ls-remote --exit-code origin "refs/tags/v${VERSION}" >/dev/null 2>&1; then
+            echo "::error::Tag v${VERSION} already exists on origin"
+            exit 1
+          fi
+
       - name: download macOS artifact
         uses: actions/download-artifact@v6
         with:
-          name: ${{ env.PROJECT_NAME }}-macOS-${{ github.ref_name }}.zip
+          name: ${{ env.MACOS_ARTIFACT }}
           path: release-assets
 
       - name: download Windows artifact
         uses: actions/download-artifact@v6
         with:
-          name: ${{ env.PROJECT_NAME }}-Windows-${{ github.ref_name }}.zip
+          name: ${{ env.WINDOWS_ARTIFACT }}
           path: release-assets
 
-      - name: publish GitHub Release
+      - name: publish GitHub Release (tag push)
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
+          files: release-assets/*
+          generate_release_notes: true
+
+      - name: publish GitHub Release (manual dispatch)
+        if: github.event_name == 'workflow_dispatch' && inputs.create_release == true
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ github.event.inputs.release_version }}
+          target_commitish: ${{ github.sha }}
           files: release-assets/*
           generate_release_notes: true
 
@@ -426,6 +503,6 @@ jobs:
           ✓ Distribution packages created
           ✓ Release assets uploaded
 
-          **Version:** ${{ github.ref_name }}
-          **Assets:** ${{ env.PROJECT_NAME }}-macOS-${{ github.ref_name }}.zip, ${{ env.PROJECT_NAME }}-Windows-${{ github.ref_name }}.zip
+          **Version:** ${{ env.RELEASE_VERSION }}
+          **Assets:** ${{ env.MACOS_ARTIFACT }}, ${{ env.WINDOWS_ARTIFACT }}
           EOF

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ cmake . -B cmake-build
 cmake --build cmake-build --config Release
 ```
 
-**Notes:** 
+**CI:** Pushes to `develop` run validation only (no downloadable artifacts). To release signed builds, push a version tag — see [Release process](docs/release.md).
+
+**Notes:**
 - The onnx library is now linked statically. No more need to download the onnx library via homebrew or via the github repository. Also the binaries are now notarized.
 - For Windows at the moment only release builds are supported. Debug builds will be supported with future updates.
 - The AU plugin has not been tested with Logic yet. Logic support will come in futher updates.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ cmake --build cmake-build --config Release
 **CI:** Pushes to `develop` run validation only (no downloadable artifacts). To release signed builds, push a version tag — see [Release process](docs/release.md).
 
 **Notes:**
-- The onnx library is now linked statically. No more need to download the onnx library via homebrew or via the github repository. Also the binaries are now notarized.
+- The onnx library is now linked statically. No more need to download the onnx library via homebrew or via the github repository. macOS release builds are code-signed with Developer ID; notarization is currently disabled in CI (since June 2024) and will be re-enabled for official releases once the release pipeline is validated.
 - For Windows at the moment only release builds are supported. Debug builds will be supported with future updates.
 - The AU plugin has not been tested with Logic yet. Logic support will come in futher updates.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,87 @@
+# Release process
+
+## CI behavior
+
+Pushing to **develop** runs validation only (build + full test suite on macOS and Windows).
+
+**No distributable artifacts are generated on develop.** This is intentional.
+
+To create downloadable builds:
+
+- Push a version tag (`vX.Y.Z`)
+- Or use **Actions → Scyclone → Run workflow** (workflow_dispatch)
+
+## Pipeline overview
+
+```mermaid
+flowchart TB
+  subgraph develop [develop push]
+    D[ci-validation]
+  end
+  subgraph tag [tag v* push]
+    T1[ci-validation] --> T2[build-distribution] --> T3[publish-release]
+  end
+  subgraph manual [workflow_dispatch]
+    M1[ci-validation] --> M2[build-distribution]
+  end
+```
+
+| Trigger | Jobs | Artifacts |
+|---------|------|-----------|
+| Push `develop` | ci-validation | None |
+| Push tag `v*` | ci-validation → build-distribution → publish-release | GitHub Release zips |
+| workflow_dispatch | ci-validation → build-distribution | Workflow artifacts (~90 days) |
+
+### Tag push vs manual dispatch
+
+| | Tag `v*` | workflow_dispatch |
+|--|----------|-------------------|
+| Purpose | Official release | Ad-hoc signed build |
+| GitHub Release | Yes | No |
+| macOS default | Universal (`arm64` + `x86_64`) | Your choice (`arm64` or `universal`) |
+| Version check | Tag must match `CMakeLists.txt` | No |
+
+## Why didn't I get artifacts?
+
+If you pushed to **develop** and expected zips:
+
+1. Check the workflow run — the step summary says validation completed with no artifacts (expected).
+2. To ship builds, tag a release or run the workflow manually from the Actions tab.
+
+Develop CI answers: *did the code compile and pass all tests?*
+
+## Release checklist
+
+1. Update version in [`CMakeLists.txt`](../CMakeLists.txt): `project(Scyclone VERSION X.Y.Z)`
+2. Commit and merge to `develop`
+3. Run the prepare-release script (optional but recommended):
+   ```bash
+   ./scripts/prepare-release.sh X.Y.Z
+   ```
+4. Create and push the tag:
+   ```bash
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+5. Open **GitHub → Releases** and confirm assets:
+   - `Scyclone-macOS-vX.Y.Z.zip`
+   - `Scyclone-Windows-vX.Y.Z.zip`
+
+CI fails the release if the tag (without `v`) does not match the CMake `VERSION`.
+
+## macOS architectures
+
+| Build type | macOS architecture |
+|------------|-------------------|
+| develop validation | arm64 (native on CI runner) |
+| version tag release | universal (`arm64` + `x86_64`) |
+| manual dispatch | arm64 or universal (your choice) |
+
+## Ad-hoc builds
+
+1. Go to **Actions → Scyclone → Run workflow**
+2. Select branch (usually `develop`)
+3. Choose **distribution_type**: `arm64` or `universal`
+4. Download zips from the workflow run (not from Releases)
+
+Manual artifact names include `-manual`, e.g. `Scyclone-macOS-universal-manual.zip`.

--- a/docs/release.md
+++ b/docs/release.md
@@ -2,7 +2,7 @@
 
 ## CI behavior
 
-Pushing to **develop** runs validation only (build + full test suite on macOS and Windows).
+Pushing to **develop** runs validation only: builds the `Test` target, plugin format targets (VST3, AU/Standalone, Windows installer), and runs the full test suite on macOS and Windows.
 
 **No distributable artifacts are generated on develop.** This is intentional.
 
@@ -23,6 +23,7 @@ flowchart TB
   end
   subgraph manual [workflow_dispatch]
     M1[ci-validation] --> M2[build-distribution]
+    M2 -->|"create_release=true"| M3[publish-release]
   end
 ```
 
@@ -31,15 +32,16 @@ flowchart TB
 | Push `develop` | ci-validation | None |
 | Push tag `v*` | ci-validation → build-distribution → publish-release | GitHub Release zips |
 | workflow_dispatch | ci-validation → build-distribution | Workflow artifacts (~90 days) |
+| workflow_dispatch + `create_release` | ci-validation → build-distribution → publish-release | GitHub Release zips |
 
 ### Tag push vs manual dispatch
 
-| | Tag `v*` | workflow_dispatch |
-|--|----------|-------------------|
-| Purpose | Official release | Ad-hoc signed build |
-| GitHub Release | Yes | No |
-| macOS default | Universal (`arm64` + `x86_64`) | Your choice (`arm64` or `universal`) |
-| Version check | Tag must match `CMakeLists.txt` | No |
+| | Tag `v*` | workflow_dispatch | workflow_dispatch + `create_release` |
+|--|----------|-------------------|--------------------------------------|
+| Purpose | Official release | Ad-hoc signed build | Publish release from Actions |
+| GitHub Release | Yes | No | Yes (creates `vX.Y.Z` tag at dispatched commit) |
+| macOS default | Universal (`arm64` + `x86_64`) | Your choice (`arm64` or `universal`) | Your choice (`arm64` or `universal`) |
+| Version check | Tag must match `CMakeLists.txt` | No | `release_version` must match `CMakeLists.txt` |
 
 ## Why didn't I get artifacts?
 
@@ -48,7 +50,7 @@ If you pushed to **develop** and expected zips:
 1. Check the workflow run — the step summary says validation completed with no artifacts (expected).
 2. To ship builds, tag a release or run the workflow manually from the Actions tab.
 
-Develop CI answers: *did the code compile and pass all tests?*
+Develop CI answers: *did the code compile, build plugin formats, and pass all tests?*
 
 ## Release checklist
 
@@ -85,3 +87,15 @@ CI fails the release if the tag (without `v`) does not match the CMake `VERSION`
 4. Download zips from the workflow run (not from Releases)
 
 Manual artifact names include `-manual`, e.g. `Scyclone-macOS-universal-manual.zip`.
+
+## Manual dispatch with GitHub Release
+
+To publish a release without pushing a tag from your machine:
+
+1. Go to **Actions → Scyclone → Run workflow**
+2. Select the branch to release (usually `develop`)
+3. Set **distribution_type** (`arm64` or `universal`)
+4. Enable **create_release**
+5. Set **release_version** to `X.Y.Z` (must match `project(Scyclone VERSION …)` in `CMakeLists.txt`)
+
+CI validates the version, builds signed zips, creates tag `vX.Y.Z` at the dispatched commit, and attaches assets to a GitHub Release. Fails if the tag already exists on the remote.

--- a/scripts/prepare-release.ps1
+++ b/scripts/prepare-release.ps1
@@ -1,0 +1,38 @@
+#Requires -Version 5.1
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$Version
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($Version -notmatch '^\d+\.\d+\.\d+$') {
+    Write-Error "Version must be semver X.Y.Z (got '$Version')"
+}
+
+$Root = Split-Path -Parent $PSScriptRoot
+$CMakeFile = Join-Path $Root 'CMakeLists.txt'
+
+$Content = Get-Content $CMakeFile -Raw
+if ($Content -notmatch 'project\s*\(\s*Scyclone\s+VERSION\s+(?<ver>[0-9.]+)') {
+    Write-Error "Could not read project(Scyclone VERSION ...) from CMakeLists.txt"
+}
+
+$CmakeVersion = $Matches['ver']
+
+Write-Host "CMake VERSION:  $CmakeVersion"
+Write-Host "Target release: $Version"
+Write-Host "Tag to push:    v$Version"
+Write-Host
+
+if ($CmakeVersion -ne $Version) {
+    Write-Error "Mismatch: update CMakeLists.txt to project(Scyclone VERSION $Version) before tagging."
+}
+
+Write-Host "Version check passed."
+Write-Host
+Write-Host "Next steps:"
+Write-Host "  git tag v$Version"
+Write-Host "  git push origin v$Version"
+Write-Host
+Write-Host "CI will validate, build signed zips, and publish a GitHub Release."

--- a/scripts/prepare-release.ps1
+++ b/scripts/prepare-release.ps1
@@ -19,14 +19,36 @@ if ($Content -notmatch 'project\s*\(\s*Scyclone\s+VERSION\s+(?<ver>[0-9.]+)') {
 }
 
 $CmakeVersion = $Matches['ver']
+$Commit = git -C $Root rev-parse --short HEAD
 
 Write-Host "CMake VERSION:  $CmakeVersion"
 Write-Host "Target release: $Version"
 Write-Host "Tag to push:    v$Version"
+Write-Host "Commit:         $Commit"
 Write-Host
 
 if ($CmakeVersion -ne $Version) {
     Write-Error "Mismatch: update CMakeLists.txt to project(Scyclone VERSION $Version) before tagging."
+}
+
+$DiffStatus = git -C $Root status --porcelain
+if ($DiffStatus) {
+    Write-Error "Working tree is not clean. Commit or stash changes before tagging."
+}
+
+$LocalTag = git -C $Root tag -l "v$Version"
+if ($LocalTag) {
+    Write-Error "Tag v$Version already exists locally."
+}
+
+git -C $Root ls-remote --exit-code origin "refs/tags/v$Version" 2>$null | Out-Null
+if ($LASTEXITCODE -eq 0) {
+    Write-Error "Tag v$Version already exists on origin."
+}
+
+$CurrentBranch = git -C $Root branch --show-current
+if ($CurrentBranch -ne 'develop') {
+    Write-Warning "Current branch is '$CurrentBranch', not 'develop'."
 }
 
 Write-Host "Version check passed."

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 X.Y.Z" >&2
+  echo "Example: $0 0.0.4" >&2
+  exit 1
+fi
+
+TARGET_VERSION="$1"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CMAKE_FILE="${ROOT}/CMakeLists.txt"
+
+if ! [[ "$TARGET_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Error: version must be semver X.Y.Z (got '$TARGET_VERSION')" >&2
+  exit 1
+fi
+
+CMAKE_VERSION=$(grep -oE 'project\([[:space:]]*Scyclone[[:space:]]+VERSION[[:space:]]+[0-9.]+' "$CMAKE_FILE" | grep -oE '[0-9.]+$' || true)
+
+if [ -z "$CMAKE_VERSION" ]; then
+  echo "Error: could not read project(Scyclone VERSION ...) from CMakeLists.txt" >&2
+  exit 1
+fi
+
+echo "CMake VERSION:  ${CMAKE_VERSION}"
+echo "Target release: ${TARGET_VERSION}"
+echo "Tag to push:    v${TARGET_VERSION}"
+echo
+
+if [ "$CMAKE_VERSION" != "$TARGET_VERSION" ]; then
+  echo "Mismatch: update CMakeLists.txt to project(Scyclone VERSION ${TARGET_VERSION}) before tagging." >&2
+  exit 1
+fi
+
+echo "Version check passed."
+echo
+echo "Next steps:"
+echo "  git tag v${TARGET_VERSION}"
+echo "  git push origin v${TARGET_VERSION}"
+echo
+echo "CI will validate, build signed zips, and publish a GitHub Release."

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -26,11 +26,32 @@ fi
 echo "CMake VERSION:  ${CMAKE_VERSION}"
 echo "Target release: ${TARGET_VERSION}"
 echo "Tag to push:    v${TARGET_VERSION}"
+echo "Commit:         $(git -C "$ROOT" rev-parse --short HEAD)"
 echo
 
 if [ "$CMAKE_VERSION" != "$TARGET_VERSION" ]; then
   echo "Mismatch: update CMakeLists.txt to project(Scyclone VERSION ${TARGET_VERSION}) before tagging." >&2
   exit 1
+fi
+
+if ! git -C "$ROOT" diff --quiet || ! git -C "$ROOT" diff --cached --quiet; then
+  echo "Error: working tree is not clean. Commit or stash changes before tagging." >&2
+  exit 1
+fi
+
+if [ -n "$(git -C "$ROOT" tag -l "v${TARGET_VERSION}")" ]; then
+  echo "Error: tag v${TARGET_VERSION} already exists locally." >&2
+  exit 1
+fi
+
+if git -C "$ROOT" ls-remote --exit-code origin "refs/tags/v${TARGET_VERSION}" >/dev/null 2>&1; then
+  echo "Error: tag v${TARGET_VERSION} already exists on origin." >&2
+  exit 1
+fi
+
+CURRENT_BRANCH="$(git -C "$ROOT" branch --show-current)"
+if [ "$CURRENT_BRANCH" != "develop" ]; then
+  echo "Warning: current branch is '${CURRENT_BRANCH}', not 'develop'." >&2
 fi
 
 echo "Version check passed."


### PR DESCRIPTION
## Summary

Refactors the monolithic CI workflow into three stages with clear triggers and documented release paths.

- **develop push** runs `ci-validation` only (build + tests, no distributable artifacts)
- **`v*` tag push** runs validation → signed distribution builds → GitHub Release publish
- **workflow_dispatch** runs validation → distribution; optional `create_release` + `release_version` publishes a GitHub Release without a local tag push
- **Faster CI**: Ninja generator, pinned ccache-action, FetchContent caching, MSVC dev environment on Windows, runner-native parallelism
- **Broader validation**: `ci-validation` builds `Test` plus plugin format targets (VST3, AU/Standalone, Windows installer) to catch packaging regressions before release
- **Release tooling**: `docs/release.md`, `prepare-release` scripts with git state guards, corrected notarization docs (signed but not notarized since June 2024)

### Pipeline

| Trigger | Jobs | Output |
|---------|------|--------|
| Push `develop` | ci-validation | None |
| Push tag `v*` | ci-validation → build-distribution → publish-release | GitHub Release zips |
| workflow_dispatch | ci-validation → build-distribution | Workflow artifacts (~90 days) |
| workflow_dispatch + `create_release` | ci-validation → build-distribution → publish-release | GitHub Release zips |

### Breaking change

Pushes to **develop** no longer upload signed zip artifacts on every commit. This is intentional — develop CI answers whether the code compiles and passes tests. Use a version tag or manual workflow dispatch to produce downloadable builds.

## Commits (10)

1. Fix compiler cache restore and pin ccache-action
2. Cache FetchContent dependencies between runs
3. Use MSVC dev environment for Windows Ninja builds
4. Run tests after building Test target only
5. Build native arm64 on macOS validation runners
6. Split into ci-validation and build-distribution jobs
7. Develop validation-only; add run summary and dispatch inputs
8. Add publish-release job with version check and provenance names
9. Add release process docs, FAQ, and prepare-release scripts
10. Wire manual release publish, plugin format validation, and doc fixes

## Test plan

- [ ] Push to this branch / merge preview: `ci-validation` passes on macOS and Windows (including new plugin-format build step)
- [ ] Push to `develop` after merge: validation only, step summary explains no artifacts
- [ ] `workflow_dispatch` with `create_release=false`: signed zips as workflow artifacts, no GitHub Release
- [ ] `workflow_dispatch` with `create_release=true` and wrong `release_version`: fails at guard step
- [ ] Tag push `vX.Y.Z` matching `CMakeLists.txt`: universal macOS build, GitHub Release with both platform zips
- [ ] `./scripts/prepare-release.sh X.Y.Z` / `prepare-release.ps1`: passes on clean tree, fails on dirty tree or existing tag

## Follow-up (out of scope)

- Re-enable macOS notarization on tag / manual release builds once this pipeline is validated on a real release
- Confirm Apple notarization secrets are still valid before re-enabling