### PR TITLE
Fix/installer

### DIFF
--- a/installer/CMakeLists.txt
+++ b/installer/CMakeLists.txt
@@ -30,7 +30,7 @@ target_sources(ScycloneInstaller
 target_compile_definitions(ScycloneInstaller
         PRIVATE
         JUCE_WEB_BROWSER=0
-        JUCE_USE_CURL=0
+        JUCE_USE_CURL=$<BOOL:${UNIX}>
         JUCE_APPLICATION_NAME_STRING="$<TARGET_PROPERTY:ScycloneInstaller,JUCE_PRODUCT_NAME>"
         JUCE_APPLICATION_VERSION_STRING="$<TARGET_PROPERTY:ScycloneInstaller,JUCE_VERSION>"
 )
@@ -43,6 +43,11 @@ juce_add_binary_data(InstallBinaryData SOURCES
 
 if(MSVC)
     SET_TARGET_PROPERTIES(ScycloneInstaller PROPERTIES LINK_FLAGS "/MANIFESTUAC:\"level='requireAdministrator' uiAccess='false'\" /SUBSYSTEM:WINDOWS")
+endif()
+
+if(UNIX)
+    find_package(CURL REQUIRED)
+    target_link_libraries(ScycloneInstaller PRIVATE CURL::libcurl)
 endif()
 
 target_link_libraries(ScycloneInstaller

--- a/installer/source/operations/OperationManager.cpp
+++ b/installer/source/operations/OperationManager.cpp
@@ -72,11 +72,7 @@ void OperationManager::repoInspectorFinished(bool status) {
     auto [downloadVersion, downloadUrl] = repoInspector.getLatestVersion();
 
     if (status && !downloadUrl.isEmpty()) {
-        #if JUCE_MAC
-            juce::String downloadFileName = juce::String{"Scyclone-"} + downloadVersion + juce::String{".dmg"};
-        #else
-            juce::String downloadFileName = juce::String{"Scyclone-"} + downloadVersion + juce::String{".zip"};
-        #endif
+        juce::String downloadFileName = juce::String{"Scyclone-"} + downloadVersion + juce::String{".zip"};
         juce::File targetFile = juce::File::getSpecialLocation(juce::File::SpecialLocationType::tempDirectory).getChildFile(downloadFileName);
         auto folderName = targetFile.getFileNameWithoutExtension();
         juce::File targetDirectory = targetFile.getParentDirectory().getChildFile(folderName);
@@ -91,10 +87,10 @@ void OperationManager::repoInspectorFinished(bool status) {
 void OperationManager::errorOccurred(ErrorCode errorCode) {
     switch (errorCode) {
         case GitHubNotAccessible:
-            std::cout << "GitHub not accessible" << std::endl;
+            DBG("GitHub not accessible");
             break;
         case InvalidDownloadLink:
-            std::cout << "Invalid download link" << std::endl;
+            DBG("Invalid download link");
             break;
     }
 }

--- a/installer/source/operations/singleOperations/PluginInstaller.cpp
+++ b/installer/source/operations/singleOperations/PluginInstaller.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "PluginInstaller.h"
+#include <filesystem>
 
 PluginInstaller::PluginInstaller() {
 }
@@ -37,23 +38,36 @@ void PluginInstaller::reset() {
 }
 
 void PluginInstaller::copyFiles() {
-    for (const auto& entry : source.findChildFiles(juce::File::findFiles, true))
+    for (const auto& entry : source.findChildFiles(juce::File::findFilesAndDirectories, false))
     {
-        std::cout << entry.getFileName() << std::endl;
-        # if JUCE_MAC 
-            if (entry.getFileExtension() == ".app" && standaloneTarget != nullptr) {
+        DBG(entry.getFileName());
+#if JUCE_MAC
+        if (entry.getFileExtension() == ".app" && standaloneTarget != nullptr) {
             auto targetFile = standaloneTarget->getChildFile(entry.getFileName());
             entry.copyFileTo(targetFile);
-            }
-        # else
-            if (entry.getFileExtension() == ".exe" && standaloneTarget != nullptr) {
-                auto targetFile = standaloneTarget->getChildFile(entry.getFileName());
-                entry.copyFileTo(targetFile);
-            }
-        # endif
+        }
+#elif JUCE_WINDOWS
+        if (entry.getFileExtension() == ".exe" && standaloneTarget != nullptr) {
+            auto targetFile = standaloneTarget->getChildFile(entry.getFileName());
+            entry.copyFileTo(targetFile);
+        }
+#elif JUCE_LINUX
+        if (entry.getFileExtension().isEmpty() && entry.existsAsFile() && standaloneTarget != nullptr) {
+            auto targetFile = standaloneTarget->getChildFile(entry.getFileName());
+            entry.copyFileTo(targetFile);
+        }
+#endif
         if (entry.getFileExtension() == ".vst3" && vst3Target != nullptr) {
             auto targetFile = vst3Target->getChildFile(entry.getFileName());
+#if JUCE_LINUX
+            std::filesystem::copy(
+                entry.getFullPathName().toStdString(),
+                targetFile.getFullPathName().toStdString(),
+                std::filesystem::copy_options::recursive | std::filesystem::copy_options::overwrite_existing
+            );
+#else
             entry.copyFileTo(targetFile);
+#endif
         } else if (entry.getFileExtension() == ".component" && auTarget != nullptr) {
             auto targetFile = auTarget->getChildFile(entry.getFileName());
             entry.copyFileTo(targetFile);

--- a/installer/source/operations/singleOperations/RepoInspector.cpp
+++ b/installer/source/operations/singleOperations/RepoInspector.cpp
@@ -22,7 +22,7 @@ void RepoInspector::inspectURL(std::string repoURL) {
 
 void RepoInspector::inspectRepo(var json) {
     std::regex osRegex("-osx-x64|-osx-arm64|-win-x64|-linux-x64");
-    std::regex versionRegex("v\\.\\d\\.\\d\\.\\d");
+    std::regex versionRegex("v\\.\\d+\\.\\d+\\.\\d+");
 
     std::map<std::string, OperatingSystem::SystemType> osMap = {
             {"-osx-x64", OperatingSystem::MacOS_x64},

--- a/installer/source/operations/singleOperations/RepoInspector.cpp
+++ b/installer/source/operations/singleOperations/RepoInspector.cpp
@@ -21,13 +21,14 @@ void RepoInspector::inspectURL(std::string repoURL) {
 }
 
 void RepoInspector::inspectRepo(var json) {
-    std::regex osRegex("-osx-x64|-osx-arm64|-win-x64");
+    std::regex osRegex("-osx-x64|-osx-arm64|-win-x64|-linux-x64");
     std::regex versionRegex("v\\.\\d\\.\\d\\.\\d");
 
     std::map<std::string, OperatingSystem::SystemType> osMap = {
             {"-osx-x64", OperatingSystem::MacOS_x64},
             {"-osx-arm64", OperatingSystem::MacOS_arm64},
-            {"-win-x64", OperatingSystem::Windows_x64}
+            {"-win-x64", OperatingSystem::Windows_x64},
+            {"-linux-x64", OperatingSystem::Linux_x64}
     };
 
     releases.clear();

--- a/installer/source/operations/singleOperations/ZipExtractor.cpp
+++ b/installer/source/operations/singleOperations/ZipExtractor.cpp
@@ -7,7 +7,7 @@
 void ZipExtractor::setSourceFile(const juce::File& pathToFile)
 {
     zipFile = std::make_unique<juce::File>(pathToFile);
-    std::cout << "ZipExtractor::setSourceFile: " << pathToFile.getFullPathName() << std::endl;
+    DBG("ZipExtractor::setSourceFile: " + pathToFile.getFullPathName());
 }
 
 void ZipExtractor::extractTo(const juce::File &destinationDirectory, bool shouldOverwriteExistingFiles) {

--- a/installer/source/ui/components/PathPage.h
+++ b/installer/source/ui/components/PathPage.h
@@ -21,8 +21,8 @@ public:
         resultPath.first = format;
         resultPath.second = DefaultPaths::getDestinationPath(format).getFullPathName();
 
-        pathLabel.onEditorShow = [this] {
-            openFileChooser("vst3", juce::File{"C:/Program Files/Common Files/VST3"});
+        pathLabel.onEditorShow = [this, format] {
+            openFileChooser(DefaultPaths::getDestinationPath(format));
         };
         pathLabel.setEditable(true, false);
         pathLabel.setLookAndFeel(&installerLookAndFeel);
@@ -47,8 +47,8 @@ public:
 
 private:
 
-    void openFileChooser(String applicationFormat, File defaultPath) {
-        fc = std::make_unique<juce::FileChooser> (juce::String{"Choose a path to save Scyclone."}+applicationFormat, defaultPath,
+    void openFileChooser(File defaultPath) {
+        fc = std::make_unique<juce::FileChooser> ("Choose a path to install Scyclone", defaultPath,
                                                   "*", true);
 
         fc->launchAsync (juce::FileBrowserComponent::openMode
@@ -71,7 +71,6 @@ private:
 
     std::unique_ptr<juce::FileChooser> fc;
 
-    std::pair<float, int> test;
     std::pair<FormatOptions::Options, juce::String> resultPath;
 
     InstallerLookAndFeel installerLookAndFeel;

--- a/installer/source/utils/DefaultPaths.h
+++ b/installer/source/utils/DefaultPaths.h
@@ -57,7 +57,10 @@ private:
         }
     }
 
-    static juce::File getStandalonePath(OperatingSystem::SystemType) {
+    static juce::File getStandalonePath(OperatingSystem::SystemType systemType) {
+        if (systemType == OS::Linux_x64) {
+            return juce::File("/usr/local/bin/Torsion Audio");
+        }
         auto globalApplicationDir = juce::File::getSpecialLocation(juce::File::SpecialLocationType::globalApplicationsDirectory);
         return globalApplicationDir.getChildFile("Torsion Audio");
     }

--- a/installer/source/utils/DefaultPaths.h
+++ b/installer/source/utils/DefaultPaths.h
@@ -39,7 +39,8 @@ private:
     static juce::File getAUPluginPath(OS::SystemType systemType) {
         if (systemType == OS::MacOS_x64 || systemType == OS::MacOS_arm64) {
             return juce::File("~/Library/Audio/Plug-Ins/Components/");
-        } else {
+        } 
+        else {
             return juce::File("");
         }
     }
@@ -47,7 +48,11 @@ private:
     static juce::File getVST3PluginPath(OperatingSystem::SystemType systemType) {
         if (systemType == OS::MacOS_x64 || systemType == OS::MacOS_arm64) {
             return juce::File("~/Library/Audio/Plug-Ins/VST3/");
-        } else {
+        } 
+        else if (systemType == OS::Linux_x64) {
+            return juce::File("/usr/lib/vst3");
+        }
+        else {
             return juce::File("C:\\Program Files\\Common Files\\VST3");
         }
     }

--- a/installer/source/utils/OperatingSystem.h
+++ b/installer/source/utils/OperatingSystem.h
@@ -10,18 +10,21 @@ struct OperatingSystem {
         Windows_x64,
         MacOS_x64,
         MacOS_arm64,
+        Linux_x64,
         Unknown
     };
 
     static SystemType getOperatingSystem() {
 #if JUCE_MAC
-        #if JUCE_64BIT
-            return MacOS_x64;
-        #else
+        #if JUCE_ARM
             return MacOS_arm64;
+        #else
+            return MacOS_x64;
         #endif
 #elif JUCE_WINDOWS
         return Windows_x64;
+#elif JUCE_LINUX || LINUX || __linux__
+        return Linux_x64;
 #else
         return Unknown;
 #endif


### PR DESCRIPTION
The installer will now always download and extract a .zip, regardless of OS. You just need to make sure the GitHub release assets are all uploaded as .zip files (not .dmg for Mac, .exe for Windows, etc.). The naming convention RepoInspector looks for is e.g. Scyclone-v1.0.0-osx-x64.zip, Scyclone-v1.0.0-win-x64.zip, Scyclone-v1.0.0-linux-x64.zip.