### PR TITLE
fix(ci): use ubuntu-24.04 for Linux runner (glibc 2.39 required by ON…

### DIFF
--- a/.github/workflows/build_test_artifacts.yml
+++ b/.github/workflows/build_test_artifacts.yml
@@ -71,7 +71,7 @@ jobs:
             os: windows-latest
             ccache: sccache
           - name: Linux
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             ccache: ccache
 
     steps:
@@ -235,7 +235,7 @@ jobs:
             ccache: sccache
             artifact_os: win-x64
           - name: Linux
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             ccache: ccache
             artifact_os: linux-x64
 


### PR DESCRIPTION
…NX Runtime)

ONNX Runtime prebuilt binary references __isoc23_strtol which was added in glibc 2.38. ubuntu-22.04 ships glibc 2.35 and fails to link. ubuntu-24.04 ships glibc 2.39 which satisfies the requirement.