### PR TITLE
fix(ci): find Linux installer binary dynamically instead of hardcoded…

### DIFF
--- a/.github/workflows/build_test_artifacts.yml
+++ b/.github/workflows/build_test_artifacts.yml
@@ -501,7 +501,9 @@ jobs:
           mkdir -p "packaging/${PRODUCT_BASE}"
           cp -r "${{ env.VST3_PATH }}" "packaging/${PRODUCT_BASE}/"
           cp "${{ env.STANDALONE_PATH }}" "packaging/${PRODUCT_BASE}/"
-          cp "${{ env.INSTALLER_PATH }}" "packaging/${PRODUCT_BASE}/"
+          INSTALLER=$(find "${{ env.BUILD_DIR }}/installer" -maxdepth 4 -type f -executable | head -1)
+          echo "Installer binary found at: $INSTALLER"
+          cp "$INSTALLER" "packaging/${PRODUCT_BASE}/ScycloneInstaller"
           cd packaging
           zip -r "${{ env.PRODUCT_ZIP }}" "${PRODUCT_BASE}/"
 


### PR DESCRIPTION
… path

JUCE names the Linux binary after PRODUCT_NAME ("Scyclone Installer") not the CMake target name ("ScycloneInstaller"). Use find -executable to locate it regardless of the exact name, then copy as ScycloneInstaller.