### PR TITLE
fix(resampler): use per-block buffer ratio for libsamplerate src_process

### DIFF
--- a/source/dsp/resampler/ResamplingProcessor.cpp
+++ b/source/dsp/resampler/ResamplingProcessor.cpp
@@ -19,6 +19,7 @@ int ResamplingProcessor::prepare(const juce::dsp::ProcessSpec &inputSpec,
 
     sampleRateRatio = calculateSampleRateRatio(targetSampleRate, inputSampleRate);
     outputBufferSize = calculateOutputBufferSize(sampleRateRatio, inputBufferSize);
+    bufferSizeRatio = calculateBufferSizeRatio(outputBufferSize, inputBufferSize);
     outputSampleRate = targetSampleRate;
     outputBuffer.setSize(1, outputBufferSize);
     outputBuffer.clear();
@@ -43,6 +44,11 @@ int ResamplingProcessor::calculateOutputBufferSize(double ratio, int blockSize)
 double ResamplingProcessor::calculateSampleRateRatio(double outputRate, double inputRate)
 {
     return outputRate / inputRate;
+}
+
+double ResamplingProcessor::calculateBufferSizeRatio(int outputBufferSize, int inputBufferSize)
+{
+    return static_cast<double>(outputBufferSize) / static_cast<double>(inputBufferSize);
 }
 
 void ResamplingProcessor::measureLatency()
@@ -104,7 +110,7 @@ juce::AudioBuffer<float>& ResamplingProcessor::processBlock(juce::AudioBuffer<fl
 
     srcData.data_out = outputBuffer.getWritePointer(0);
     srcData.output_frames = outputBuffer.getNumSamples();
-    srcData.src_ratio = sampleRateRatio;
+    srcData.src_ratio = bufferSizeRatio;
     srcData.end_of_input = 0;
 
     int error = src_process(converter, &srcData);

--- a/source/dsp/resampler/ResamplingProcessor.h
+++ b/source/dsp/resampler/ResamplingProcessor.h
@@ -26,9 +26,11 @@ private:
     int outputBufferSize = 0;
 
     double sampleRateRatio = 1.0;
+    double bufferSizeRatio = 1.0;
 
     double calculateSampleRateRatio(double outputRate, double inputRate);
     int calculateOutputBufferSize(double ratio, int blockSize);
+    double calculateBufferSizeRatio(int outputBufferSize, int inputBufferSize);
     void measureLatency();
     void printMetrics();
 


### PR DESCRIPTION
## Summary

- Separates **nominal sample-rate ratio** (`sampleRateRatio = f_s,out / f_s,in`) from the **per-block buffer ratio** passed to libsamplerate (`bufferSizeRatio = N_out / N_in`).
- After `ceil` output sizing, `N_out / N_in` can differ slightly from the nominal rate ratio; `src_process` expects the ratio that matches the fixed input/output frame counts for each block, not the abstract sample-rate ratio alone.
- Keeps `sampleRateRatio` for buffer sizing and latency measurement; routes `srcData.src_ratio` through the new `bufferSizeRatio` field and `calculateBufferSizeRatio()` helper for clearer intent.

Cherry-picked from `555f55694735a3aaec866766a11112b71aaa06b1`.

## Problem

`ResamplingProcessor::prepare()` sizes the output buffer with `ceil(sampleRateRatio * blockSize)`. That rounding step means the effective conversion ratio for a fixed block is `outputBufferSize / inputBufferSize`, which is not always identical to `targetSampleRate / inputSampleRate`.

Previously, `processBlock()` passed `sampleRateRatio` to `srcData.src_ratio`. For ratios where `ceil` introduces a small drift (common on upsampling paths), libsamplerate would consume/produce frames at a rate that did not match the prepared buffer geometry, leading to subtle block-boundary misalignment over time.

## Solution

```cpp
sampleRateRatio   = targetRate / inputRate;           // nominal — sizing & latency
outputBufferSize  = ceil(sampleRateRatio * blockSize);
bufferSizeRatio   = outputBufferSize / inputBufferSize; // per-block — src_process
srcData.src_ratio = bufferSizeRatio;
```

## Test plan

- [ ] Build plugin and test target on Windows (`cmake --preset dev && cmake --build --preset dev`)
- [ ] Run existing resampling / latency tests if available on this branch
- [ ] Smoke-test host playback at 44.1 kHz and 48 kHz with ONNX inference enabled (up/down resampling paths)
- [ ] Verify dry/wet alignment and reported plugin latency remain stable across block-size changes
