### PR TITLE
ci: test infrastructure - shared setup actions, sanitizer gates, and maintainer docs

### DIFF
--- a/.github/actions/juce-linux-deps/action.yml
+++ b/.github/actions/juce-linux-deps/action.yml
@@ -14,7 +14,10 @@ runs:
           libx11-dev \
           libxcomposite-dev \
           libxcursor-dev \
+          libxext-dev \
+          libxi-dev \
           libxinerama-dev \
           libxrandr-dev \
+          libgl1-mesa-dev \
           libglu1-mesa-dev \
           libcurl4-openssl-dev

--- a/.github/actions/sanitizer-job-summary/action.yml
+++ b/.github/actions/sanitizer-job-summary/action.yml
@@ -1,0 +1,51 @@
+name: Sanitizer job summary
+description: Write a GITHUB_STEP_SUMMARY for sanitizer CI jobs
+
+inputs:
+  title:
+    description: Summary heading
+    required: true
+  preset:
+    description: SCYCLONE_SANITIZERS / CMake preset name
+    required: true
+  build_dir:
+    description: CMake binary directory
+    required: true
+  gate:
+    description: Merge gate policy (required or advisory)
+    required: true
+  runtime_env:
+    description: Sanitizer runtime environment variables used
+    required: false
+    default: ''
+  outcome:
+    description: Job outcome (success, failure, etc.)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Write summary
+      shell: bash
+      run: |
+        {
+          echo "## ${{ inputs.title }}"
+          echo ""
+          echo "| Field | Value |"
+          echo "|-------|-------|"
+          echo "| Preset | \`${{ inputs.preset }}\` |"
+          echo "| Build dir | \`${{ inputs.build_dir }}\` |"
+          echo "| Tests | \`ctest -L default\` |"
+          echo "| Merge gate | **${{ inputs.gate }}** |"
+          if [ -n "${{ inputs.runtime_env }}" ]; then
+            echo "| Runtime env | \`${{ inputs.runtime_env }}\` |"
+          fi
+          echo ""
+          if [ "${{ inputs.outcome }}" = "success" ]; then
+            echo "✓ Sanitizer job completed successfully."
+          else
+            echo "✗ Sanitizer job finished with: **${{ inputs.outcome }}**"
+            echo ""
+            echo "See [TESTING_SANITIZERS.md](docs/maintainer/TESTING_SANITIZERS.md) — **When CI breaks**."
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/set-parallel-build-level/action.yml
+++ b/.github/actions/set-parallel-build-level/action.yml
@@ -1,0 +1,16 @@
+name: Set parallel build level
+description: Export CMAKE_BUILD_PARALLEL_LEVEL to GITHUB_ENV from runner CPU count
+
+runs:
+  using: composite
+  steps:
+    - name: Set parallel build level
+      shell: bash
+      run: |
+        if [ "${{ runner.os }}" = "Windows" ]; then
+          echo "CMAKE_BUILD_PARALLEL_LEVEL=${NUMBER_OF_PROCESSORS}" >> "$GITHUB_ENV"
+        elif [ "${{ runner.os }}" = "Linux" ]; then
+          echo "CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)" >> "$GITHUB_ENV"
+        else
+          echo "CMAKE_BUILD_PARALLEL_LEVEL=$(sysctl -n hw.ncpu)" >> "$GITHUB_ENV"
+        fi

--- a/.github/actions/setup-linux-juce/action.yml
+++ b/.github/actions/setup-linux-juce/action.yml
@@ -1,0 +1,31 @@
+name: Setup Linux (JUCE)
+description: Build tools and JUCE system dependencies for Ubuntu CI runners
+
+inputs:
+  install_clang:
+    description: Install clang and llvm (ThreadSanitizer jobs)
+    required: false
+    default: 'false'
+  extra_packages:
+    description: Space-separated extra apt packages (e.g. python3 curl for MSan libc++ build)
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Install build tools
+      shell: bash
+      run: |
+        sudo apt-get update
+        PACKAGES="build-essential cmake ninja-build"
+        if [ "${{ inputs.install_clang }}" = "true" ]; then
+          PACKAGES="$PACKAGES clang llvm"
+        fi
+        if [ -n "${{ inputs.extra_packages }}" ]; then
+          PACKAGES="$PACKAGES ${{ inputs.extra_packages }}"
+        fi
+        # shellcheck disable=SC2086
+        sudo apt-get install -y $PACKAGES
+
+    - uses: ./.github/actions/juce-linux-deps

--- a/.github/actions/setup-macos-juce/action.yml
+++ b/.github/actions/setup-macos-juce/action.yml
@@ -1,0 +1,27 @@
+name: Setup macOS (JUCE)
+description: Homebrew tools and Xcode pin for JUCE 7 CI on macos-14
+
+inputs:
+  install_osxutils:
+    description: Install osxutils (distribution / validation builds)
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Install Homebrew packages
+      shell: bash
+      run: |
+        if [ "${{ inputs.install_osxutils }}" = "true" ]; then
+          brew install osxutils ninja
+        else
+          brew install ninja
+        fi
+
+    # TEMPORARY: JUCE 7.0.5 does not build juceaide against the macOS 15 SDK (Xcode 16+).
+    # Pin Xcode 15.4 until JUCE is upgraded (https://github.com/juce-framework/JUCE/issues/1427).
+    - name: Pin Xcode for JUCE 7 compatibility
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '15.4'

--- a/.github/actions/setup-msvc/action.yml
+++ b/.github/actions/setup-msvc/action.yml
@@ -1,0 +1,42 @@
+name: Setup MSVC
+description: Resolve Visual Studio via vswhere and export toolchain env vars to GITHUB_ENV
+
+inputs:
+  export_asan_path:
+    description: Export MSVC AddressSanitizer runtime bin path as asan_bin_path output
+    required: false
+    default: 'false'
+
+outputs:
+  asan_bin_path:
+    description: Path to MSVC ASan DLLs (when export_asan_path is true)
+    value: ${{ steps.setup.outputs.asan_bin_path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Setup MSVC
+      id: setup
+      shell: pwsh
+      run: |
+        $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        if (-not (Test-Path $vswhere)) { throw "vswhere.exe not found" }
+        $vsPath = & $vswhere -latest -products * `
+          -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+          -property installationPath
+        if (-not $vsPath) { throw "Visual Studio with C++ tools not found" }
+        $vcvars = Join-Path $vsPath 'VC\Auxiliary\Build\vcvars64.bat'
+        if (-not (Test-Path $vcvars)) { throw "vcvars64.bat not found at $vcvars" }
+        $vctoolsInstallDir = $null
+        cmd /c "`"$vcvars`" && set" | ForEach-Object {
+          if ($_ -match '^([^=]+)=(.*)$') {
+            Add-Content -Path $env:GITHUB_ENV -Value "$($matches[1])=$($matches[2])"
+            if ($matches[1] -eq 'VCToolsInstallDir') { $vctoolsInstallDir = $matches[2] }
+          }
+        }
+        if ("${{ inputs.export_asan_path }}" -eq "true") {
+          if (-not $vctoolsInstallDir) { throw "VCToolsInstallDir not set by vcvars64.bat" }
+          $asanBinPath = Join-Path $vctoolsInstallDir "bin\Hostx64\x64"
+          if (-not (Test-Path $asanBinPath)) { throw "MSVC ASan bin path not found: $asanBinPath" }
+          echo "asan_bin_path=$asanBinPath" >> $env:GITHUB_OUTPUT
+        }

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,6 +1,6 @@
 name: Build & Test
 
-# CI Model
+# CI Model (see docs/maintainer/release.md for releases)
 #
 # pull_request / develop push:
 #   - ci-validation only
@@ -78,34 +78,16 @@ jobs:
             ccache: ccache
 
     steps:
-      - name: install macOS deps
-        if: matrix.name == 'macOS'
-        run: brew install osxutils ninja
-
-      - name: install Linux deps
-        if: matrix.name == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ninja-build libfreetype6-dev libx11-dev libxext-dev \
-            libxinerama-dev libxrandr-dev libxcursor-dev libxi-dev libgl1-mesa-dev \
-            libasound2-dev libcurl4-openssl-dev
-
       - name: get repo and submodules
         uses: actions/checkout@v6
         with:
           submodules: true # JUCE, libsamplerate, etc.
 
-      # TEMPORARY: JUCE 7.0.5 calls CGWindowListCreateImage, which Apple removed from the
-      # macOS 15 SDK (Xcode 16+). That breaks juceaide during cmake configure - unrelated to
-      # our deployment target; binaries can still run on macOS 10.13+ (see configure_platform.cmake).
-      # Pin Xcode 15.4 (macOS 14.5 SDK) until we upgrade JUCE to develop or JUCE 8, where the
-      # ScreenCaptureKit fix is proven upstream (https://github.com/juce-framework/JUCE/issues/1427).
-      # Then switch back to macos-latest and remove this step.
-      - name: pin Xcode for JUCE 7 compatibility (macOS)
+      - uses: ./.github/actions/setup-macos-juce
         if: matrix.name == 'macOS'
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '15.4'
+
+      - uses: ./.github/actions/setup-linux-juce
+        if: matrix.name == 'Linux'
 
       - name: restore FetchContent cache
         uses: actions/cache@v4
@@ -119,37 +101,10 @@ jobs:
         if: runner.os == 'Windows'
         run: choco install ninja
 
-      # Resolve VS via vswhere (ships with VS; survives VS 2022/2026 runner images).
-      # Exports cl.exe/link.exe env vars to GITHUB_ENV for subsequent bash steps.
-      - name: setup MSVC
+      - uses: ./.github/actions/setup-msvc
         if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          if (-not (Test-Path $vswhere)) { throw "vswhere.exe not found" }
-          $vsPath = & $vswhere -latest -products * `
-            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
-            -property installationPath
-          if (-not $vsPath) { throw "Visual Studio with C++ tools not found" }
-          $vcvars = Join-Path $vsPath 'VC\Auxiliary\Build\vcvars64.bat'
-          if (-not (Test-Path $vcvars)) { throw "vcvars64.bat not found at $vcvars" }
-          cmd /c "`"$vcvars`" && set" | ForEach-Object {
-            if ($_ -match '^([^=]+)=(.*)$') {
-              Add-Content -Path $env:GITHUB_ENV -Value "$($matches[1])=$($matches[2])"
-            }
-          }
 
-      # Use all runner CPU cores (replaces the old fixed CMAKE_BUILD_PARALLEL_LEVEL: 4).
-      - name: set parallel build level
-        shell: bash
-        run: |
-          if [ "${{ runner.os }}" = "Windows" ]; then
-            echo "CMAKE_BUILD_PARALLEL_LEVEL=${NUMBER_OF_PROCESSORS}" >> "$GITHUB_ENV"
-          elif [ "${{ runner.os }}" = "Linux" ]; then
-            echo "CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)" >> "$GITHUB_ENV"
-          else
-            echo "CMAKE_BUILD_PARALLEL_LEVEL=$(sysctl -n hw.ncpu)" >> "$GITHUB_ENV"
-          fi
+      - uses: ./.github/actions/set-parallel-build-level
 
       # append-timestamp: false avoids proliferating cache keys that never restore.
       - name: ccache
@@ -247,29 +202,16 @@ jobs:
             artifact_os: linux-x64
 
     steps:
-      - name: install macOS deps
-        if: matrix.name == 'macOS'
-        run: brew install osxutils ninja
-
-      - name: install Linux deps
-        if: matrix.name == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ninja-build libfreetype6-dev libx11-dev libxext-dev \
-            libxinerama-dev libxrandr-dev libxcursor-dev libxi-dev libgl1-mesa-dev \
-            libasound2-dev libcurl4-openssl-dev
-
       - name: get repo and submodules
         uses: actions/checkout@v6
         with:
           submodules: true
 
-      # TEMPORARY: JUCE 7.0.5 / Xcode 16+ — see ci-validation job for full explanation.
-      - name: pin Xcode for JUCE 7 compatibility (macOS)
+      - uses: ./.github/actions/setup-macos-juce
         if: matrix.name == 'macOS'
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '15.4'
+
+      - uses: ./.github/actions/setup-linux-juce
+        if: matrix.name == 'Linux'
 
       - name: verify tag matches CMake version
         if: startsWith(github.ref, 'refs/tags/v')
@@ -355,37 +297,10 @@ jobs:
         if: runner.os == 'Windows'
         run: choco install ninja
 
-      # Resolve VS via vswhere (ships with VS; survives VS 2022/2026 runner images).
-      # Exports cl.exe/link.exe env vars to GITHUB_ENV for subsequent bash steps.
-      - name: setup MSVC
+      - uses: ./.github/actions/setup-msvc
         if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          if (-not (Test-Path $vswhere)) { throw "vswhere.exe not found" }
-          $vsPath = & $vswhere -latest -products * `
-            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
-            -property installationPath
-          if (-not $vsPath) { throw "Visual Studio with C++ tools not found" }
-          $vcvars = Join-Path $vsPath 'VC\Auxiliary\Build\vcvars64.bat'
-          if (-not (Test-Path $vcvars)) { throw "vcvars64.bat not found at $vcvars" }
-          cmd /c "`"$vcvars`" && set" | ForEach-Object {
-            if ($_ -match '^([^=]+)=(.*)$') {
-              Add-Content -Path $env:GITHUB_ENV -Value "$($matches[1])=$($matches[2])"
-            }
-          }
 
-      # Use all runner CPU cores (replaces the old fixed CMAKE_BUILD_PARALLEL_LEVEL: 4).
-      - name: set parallel build level
-        shell: bash
-        run: |
-          if [ "${{ runner.os }}" = "Windows" ]; then
-            echo "CMAKE_BUILD_PARALLEL_LEVEL=${NUMBER_OF_PROCESSORS}" >> "$GITHUB_ENV"
-          elif [ "${{ runner.os }}" = "Linux" ]; then
-            echo "CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)" >> "$GITHUB_ENV"
-          else
-            echo "CMAKE_BUILD_PARALLEL_LEVEL=$(sysctl -n hw.ncpu)" >> "$GITHUB_ENV"
-          fi
+      - uses: ./.github/actions/set-parallel-build-level
 
       # append-timestamp: false avoids proliferating cache keys that never restore.
       - name: ccache

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,8 +1,8 @@
-name: Scyclone
+name: Build & Test
 
 # CI Model
 #
-# develop push:
+# pull_request / develop push:
 #   - ci-validation only
 #   - no distributable artifacts (this is intentional)
 #
@@ -21,6 +21,8 @@ on:
   push:
     branches: [ develop ]
     tags: [ 'v*' ]
+  pull_request:
+    branches: [ develop ]
   workflow_dispatch:
     inputs:
       distribution_type:
@@ -41,6 +43,7 @@ run-name: >-
   ${{
     startsWith(github.ref, 'refs/tags/v') && format('Release {0}', github.ref_name) ||
     github.event_name == 'workflow_dispatch' && format('Manual build ({0}, {1})', inputs.distribution_type, github.ref_name) ||
+    github.event_name == 'pull_request' && format('PR #{0} validation', github.event.pull_request.number) ||
     format('Validation ({0})', github.ref_name)
   }}
 
@@ -208,13 +211,13 @@ jobs:
           ✓ Tests passed
 
           EOF
-          if [ "${{ github.ref }}" = "refs/heads/develop" ]; then
+          if [ "${{ github.event_name }}" = "pull_request" ] || [ "${{ github.ref }}" = "refs/heads/develop" ]; then
             cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
-          **No distributable artifacts were produced.** This is expected for develop pushes.
+          **No distributable artifacts were produced.** This is expected for PRs and develop pushes.
 
           To create downloadable builds:
           - Push a version tag (`vX.Y.Z`)
-          - Or run **Actions → Scyclone → Run workflow**
+          - Or run **Actions → Build & Test → Run workflow**
           EOF
           fi
 

--- a/.github/workflows/sanitizers-advisory.yml
+++ b/.github/workflows/sanitizers-advisory.yml
@@ -1,0 +1,261 @@
+# Advisory / experimental sanitizer jobs — do not block merge.
+# Policy: docs/maintainer/TESTING_SANITIZERS.md
+name: Sanitizers (advisory)
+
+on:
+  push:
+    branches: [develop]
+    tags: ['v*']
+  pull_request:
+    branches: [develop]
+  workflow_dispatch:
+
+run-name: >-
+  ${{
+    github.event_name == 'pull_request' && format('Sanitizers advisory PR #{0}', github.event.pull_request.number) ||
+    startsWith(github.ref, 'refs/tags/v') && format('Sanitizers advisory release {0}', github.ref_name) ||
+    format('Sanitizers advisory ({0})', github.ref_name)
+  }}
+
+concurrency:
+  group: sanitizers-advisory-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  SCYCLONE_MSAN_LIBCXX_LLVM_TAG: llvmorg-14.0.6
+
+jobs:
+  sanitize-asan-msvc-windows:
+    name: '[advisory] ASan (Windows MSVC)'
+    runs-on: windows-latest
+    timeout-minutes: 120
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Install Ninja
+        run: choco install ninja --yes
+
+      - uses: ./.github/actions/setup-msvc
+        id: setup_msvc
+        with:
+          export_asan_path: 'true'
+
+      - name: Configure (CMake preset asan)
+        shell: bash
+        run: cmake --preset asan
+
+      - name: Build Test
+        shell: bash
+        run: cmake --build --preset asan
+
+      - name: Run tests
+        shell: pwsh
+        run: |
+          $env:PATH = "${{ steps.setup_msvc.outputs.asan_bin_path }};$env:PATH"
+          ctest --test-dir build-asan -C RelWithDebInfo -L default --output-on-failure
+
+      - uses: ./.github/actions/sanitizer-job-summary
+        if: always()
+        with:
+          title: '[advisory] ASan (Windows MSVC)'
+          preset: ASAN / asan (ONNX stub)
+          build_dir: build-asan
+          gate: advisory — continue-on-error
+          outcome: ${{ job.status }}
+
+  sanitize-msan-linux:
+    name: '[advisory] MSan (Linux)'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - uses: ./.github/actions/setup-linux-juce
+        with:
+          install_clang: 'true'
+          extra_packages: python3 curl
+
+      - name: Cache MSan-instrumented libc++
+        id: msan_libcxx
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/msan-libcxx-prefix
+          key: msan-libcxx-${{ runner.os }}-${{ env.SCYCLONE_MSAN_LIBCXX_LLVM_TAG }}-v2-${{ hashFiles('.github/workflows/sanitizers-advisory.yml', 'cmake/ScycloneSanitizers.cmake') }}
+
+      - name: Build MSan-instrumented libc++/libc++abi (LLVM)
+        if: steps.msan_libcxx.outputs.cache-hit != 'true'
+        timeout-minutes: 45
+        run: |
+          set -euxo pipefail
+          TAG="${SCYCLONE_MSAN_LIBCXX_LLVM_TAG}"
+          VER="${TAG#llvmorg-}"
+          curl -fsSL -o /tmp/llvm-project.tar.xz \
+            "https://github.com/llvm/llvm-project/releases/download/${TAG}/llvm-project-${VER}.src.tar.xz"
+          tar xf /tmp/llvm-project.tar.xz -C /tmp
+          SRC="/tmp/llvm-project-${VER}.src"
+          PREFIX="${GITHUB_WORKSPACE}/msan-libcxx-prefix"
+          cmake -S "${SRC}/llvm" -B /tmp/libcxx-msan-b -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DLLVM_ENABLE_PROJECTS='libcxx;libcxxabi' \
+            -DLLVM_TARGETS_TO_BUILD=X86 \
+            -DLLVM_INCLUDE_TESTS=OFF \
+            -DLLVM_INCLUDE_BENCHMARKS=OFF \
+            -DLLVM_INCLUDE_EXAMPLES=OFF \
+            -DLLVM_INCLUDE_DOCS=OFF \
+            -DLLVM_ENABLE_BINDINGS=OFF \
+            -DLLVM_ENABLE_Z3_SOLVER=OFF \
+            -DLLVM_USE_SANITIZER=Memory
+          cmake --build /tmp/libcxx-msan-b --target cxx cxxabi
+          rm -rf "${PREFIX}"
+          mkdir -p "${PREFIX}/include/c++" "${PREFIX}/lib"
+          if [ -d /tmp/libcxx-msan-b/include/c++/v1 ]; then
+            cp -a /tmp/libcxx-msan-b/include/c++/v1 "${PREFIX}/include/c++/"
+          else
+            echo "Missing generated libc++ headers under build/include/c++/v1"
+            find /tmp/libcxx-msan-b -maxdepth 4 -type d -name v1 2>/dev/null | head
+            exit 1
+          fi
+          while IFS= read -r -d '' f; do cp -P "$f" "${PREFIX}/lib/"; done < <(find /tmp/libcxx-msan-b/lib -maxdepth 3 \( -name 'libc++.so*' -o -name 'libc++abi.so*' \) -print0)
+          for f in /tmp/libcxx-msan-b/lib/libc++.a /tmp/libcxx-msan-b/lib/libc++abi.a; do
+            [ -f "$f" ] && cp -P "$f" "${PREFIX}/lib/" || true
+          done
+          compgen -G "${PREFIX}/lib/libc++.so*" >/dev/null || { echo "No libc++.so under ${PREFIX}/lib"; ls -la "${PREFIX}/lib"; exit 1; }
+
+      - name: Configure (MEMORY - Linux + Clang)
+        env:
+          CC: clang
+          CXX: clang++
+        run: |
+          cmake -G Ninja -B build-msan -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSCYCLONE_SANITIZERS=MEMORY \
+            -DSCYCLONE_MSAN_LIBCXX_PREFIX="${GITHUB_WORKSPACE}/msan-libcxx-prefix"
+
+      - name: Build Test
+        env:
+          LD_LIBRARY_PATH: ${{ github.workspace }}/msan-libcxx-prefix/lib:${{ env.LD_LIBRARY_PATH }}
+        run: cmake --build build-msan --target Test --parallel
+
+      - name: Run tests
+        env:
+          MSAN_OPTIONS: halt_on_error=1
+          LD_LIBRARY_PATH: ${{ github.workspace }}/msan-libcxx-prefix/lib:${{ env.LD_LIBRARY_PATH }}
+        run: ctest --test-dir build-msan -L default --output-on-failure
+
+      - uses: ./.github/actions/sanitizer-job-summary
+        if: always()
+        with:
+          title: '[advisory] MSan (Linux)'
+          preset: MEMORY (ONNX stub, instrumented libc++)
+          build_dir: build-msan
+          gate: advisory — continue-on-error
+          runtime_env: MSAN_OPTIONS=halt_on_error=1
+          outcome: ${{ job.status }}
+
+  # Homebrew Clang 18 + ASan detect_leaks — experimental macOS leak probe (Apple Clang has no detect_leaks).
+  sanitize-asan-leaks-macos:
+    name: '[advisory] ASan leaks probe (macOS)'
+    runs-on: macos-14
+    timeout-minutes: 120
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Cache Homebrew downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/Homebrew
+          key: ${{ runner.os }}-homebrew-downloads-llvm-18-${{ hashFiles('.github/workflows/sanitizers-advisory.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-homebrew-downloads-
+
+      - name: Install Homebrew LLVM 18 (for ASan + detect_leaks)
+        run: |
+          brew install llvm@18
+          LLVM_PREFIX="$(brew --prefix llvm@18)"
+          if [ ! -x "$LLVM_PREFIX/bin/clang" ]; then
+            brew reinstall llvm@18
+            LLVM_PREFIX="$(brew --prefix llvm@18)"
+          fi
+          echo "CC=$LLVM_PREFIX/bin/clang" >> "$GITHUB_ENV"
+          echo "CXX=$LLVM_PREFIX/bin/clang++" >> "$GITHUB_ENV"
+          echo "PATH=$LLVM_PREFIX/bin:$PATH" >> "$GITHUB_ENV"
+
+      - uses: ./.github/actions/setup-macos-juce
+        with:
+          install_osxutils: 'false'
+
+      - name: Configure (ASAN_UBSAN — Homebrew Clang, ONNX stub auto)
+        run: |
+          cmake -G Ninja -B build-asan-leaks-macos -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_OSX_ARCHITECTURES=arm64 \
+            -DSCYCLONE_SANITIZERS=ASAN_UBSAN
+
+      - name: Build Test
+        run: cmake --build build-asan-leaks-macos --target Test --parallel
+
+      - name: Run tests (leaks warn-only)
+        id: leak_probe
+        env:
+          ASAN_OPTIONS: detect_leaks=1:abort_on_error=0
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=0
+          LSAN_OPTIONS: exitcode=0:print_summary=1:suppressions=${{ github.workspace }}/test/sanitizer/lsan-macos.supp
+        run: |
+          set -o pipefail
+          ctest --test-dir build-asan-leaks-macos -L default --output-on-failure 2>&1 | tee ctest-leak-probe.log
+          if grep -qE 'LeakSanitizer: CHECK failed|Subprocess aborted' ctest-leak-probe.log; then
+            echo "LSan internal abort detected — probe failed (see llvm/llvm-project#117476)"
+            exit 1
+          fi
+
+      - name: Upload leak probe log on failure
+        if: failure() && steps.leak_probe.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: sanitize-asan-leaks-macos-log
+          path: ctest-leak-probe.log
+          retention-days: 14
+
+      - uses: ./.github/actions/sanitizer-job-summary
+        if: always()
+        with:
+          title: '[advisory] ASan leaks probe (macOS)'
+          preset: ASAN_UBSAN + Homebrew Clang + detect_leaks=1
+          build_dir: build-asan-leaks-macos
+          gate: advisory — informational leak probe
+          runtime_env: ASAN_OPTIONS=detect_leaks=1:abort_on_error=0; LSAN suppressions in test/sanitizer/lsan-macos.supp
+          outcome: ${{ job.status }}
+
+  sanitizers-advisory-summary:
+    name: sanitizers-advisory-summary
+    needs:
+      - sanitize-asan-msvc-windows
+      - sanitize-msan-linux
+      - sanitize-asan-leaks-macos
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Advisory summary
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          # Sanitizers — advisory jobs
+
+          These jobs use `continue-on-error` and **do not block merge**.
+
+          | Job | Purpose |
+          |-----|---------|
+          | Windows MSVC ASan | Memory checks with ONNX stub |
+          | Linux MSan | Uninitialized-read probe (experimental) |
+          | macOS leak probe | Homebrew Clang + `detect_leaks=1` |
+
+          Promotion criteria: see `docs/maintainer/TESTING_SANITIZERS.md`.
+          EOF

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,23 +1,29 @@
-# Sanitizer CI: builds Test target only (not plugin formats).
-# Presets via -DSCYCLONE_SANITIZERS=... (see cmake/ScycloneSanitizers.cmake).
+# Required sanitizer gates — builds Test target only (not plugin formats).
+# Policy: cmake/ScycloneSanitizers.cmake. Maintainer doc: docs/maintainer/TESTING_SANITIZERS.md
 name: Sanitizers
 
 on:
   push:
     branches: [develop]
+    tags: ['v*']
   pull_request:
     branches: [develop]
   workflow_dispatch:
 
+run-name: >-
+  ${{
+    github.event_name == 'pull_request' && format('Sanitizers PR #{0}', github.event.pull_request.number) ||
+    startsWith(github.ref, 'refs/tags/v') && format('Sanitizers release {0}', github.ref_name) ||
+    format('Sanitizers ({0})', github.ref_name)
+  }}
+
 concurrency:
   group: sanitizers-${{ github.ref }}
-  cancel-in-progress: true
-
-env:
-  SCYCLONE_MSAN_LIBCXX_LLVM_TAG: llvmorg-14.0.6
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   sanitize-asan-ubsan-linux:
+    name: ASan+UBSan (Linux)
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
@@ -25,33 +31,37 @@ jobs:
         with:
           submodules: true
 
-      - name: Install build tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential cmake ninja-build
+      - uses: ./.github/actions/setup-linux-juce
 
-      - uses: ./.github/actions/juce-linux-deps
-
-      - name: Configure (ASAN_UBSAN)
-        run: |
-          cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSCYCLONE_SANITIZERS=ASAN_UBSAN
+      - name: Configure (CMake preset asan-ubsan)
+        run: cmake --preset asan-ubsan
 
       - name: Build Test
-        run: cmake --build build --target Test --parallel
+        run: cmake --build --preset asan-ubsan
 
       - name: Run tests
         env:
           ASAN_OPTIONS: detect_leaks=1:abort_on_error=1
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
-        run: ctest --test-dir build -L default --output-on-failure
+        run: ctest --test-dir build-asan-ubsan -L default --output-on-failure
 
       - name: SNR calibration probe (Linux diagnostic)
         continue-on-error: true
-        run: ./build/Test --gtest_filter=*PrintSnrMeasurements* --gtest_also_run_disabled_tests
+        run: ./build-asan-ubsan/Test --gtest_filter=*PrintSnrMeasurements* --gtest_also_run_disabled_tests
 
-  # Apple Clang does not support detect_leaks in ASAN_OPTIONS. Required leak gate: sanitize-asan-ubsan-linux.
-  # Experimental macOS probe: sanitize-asan-leaks-macos (Homebrew Clang + detect_leaks=1).
+      - uses: ./.github/actions/sanitizer-job-summary
+        if: always()
+        with:
+          title: ASan+UBSan (Linux)
+          preset: ASAN_UBSAN / asan-ubsan
+          build_dir: build-asan-ubsan
+          gate: required — authoritative leak gate (detect_leaks=1)
+          runtime_env: ASAN_OPTIONS=detect_leaks=1:abort_on_error=1; UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1
+          outcome: ${{ job.status }}
+
+  # Apple Clang does not support detect_leaks in ASAN_OPTIONS. Leak gate: sanitize-asan-ubsan-linux.
   sanitize-asan-ubsan-macos:
+    name: ASan+UBSan (macOS)
     runs-on: macos-14
     timeout-minutes: 120
     steps:
@@ -59,86 +69,38 @@ jobs:
         with:
           submodules: true
 
-      - name: Install Ninja
-        run: brew install ninja
-
-      - name: Pin Xcode for JUCE 7 compatibility
-        uses: maxim-lobanov/setup-xcode@v1
+      - uses: ./.github/actions/setup-macos-juce
         with:
-          xcode-version: '15.4'
+          install_osxutils: 'false'
 
-      - name: Configure (ASAN_UBSAN)
-        run: |
-          cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_OSX_ARCHITECTURES=arm64 \
-            -DSCYCLONE_SANITIZERS=ASAN_UBSAN
+      - name: Configure (CMake preset asan-ubsan)
+        run: cmake --preset asan-ubsan -DCMAKE_OSX_ARCHITECTURES=arm64
 
       - name: Build Test
-        run: cmake --build build --target Test --parallel
+        run: cmake --build --preset asan-ubsan
 
       - name: Run tests
         env:
           ASAN_OPTIONS: abort_on_error=1
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
-        run: ctest --test-dir build -L default --output-on-failure
+        run: ctest --test-dir build-asan-ubsan -L default --output-on-failure
 
       - name: SNR calibration probe (macOS diagnostic)
         continue-on-error: true
-        run: ./build/Test --gtest_filter=*PrintSnrMeasurements* --gtest_also_run_disabled_tests
+        run: ./build-asan-ubsan/Test --gtest_filter=*PrintSnrMeasurements* --gtest_also_run_disabled_tests
 
-  sanitize-asan-msvc-windows:
-    runs-on: windows-latest
-    timeout-minutes: 120
-    # Prebuilt ORT lacks MSVC ASan STL annotations (LNK2038); SCYCLONE_SANITIZER_STUB_ONNX skips ORT link.
-    # PluginIntegrationTest skips under stub; resampling/mixer tests still run. continue-on-error until stable.
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v6
+      - uses: ./.github/actions/sanitizer-job-summary
+        if: always()
         with:
-          submodules: true
-
-      - name: Install Ninja
-        run: choco install ninja --yes
-
-      - name: Setup MSVC
-        id: setup_msvc
-        shell: pwsh
-        run: |
-          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          if (-not (Test-Path $vswhere)) { throw "vswhere.exe not found" }
-          $vsPath = & $vswhere -latest -products * `
-            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
-            -property installationPath
-          if (-not $vsPath) { throw "Visual Studio with C++ tools not found" }
-          $vcvars = Join-Path $vsPath 'VC\Auxiliary\Build\vcvars64.bat'
-          if (-not (Test-Path $vcvars)) { throw "vcvars64.bat not found at $vcvars" }
-          $vctoolsInstallDir = $null
-          cmd /c "`"$vcvars`" && set" | ForEach-Object {
-            if ($_ -match '^([^=]+)=(.*)$') {
-              Add-Content -Path $env:GITHUB_ENV -Value "$($matches[1])=$($matches[2])"
-              if ($matches[1] -eq 'VCToolsInstallDir') { $vctoolsInstallDir = $matches[2] }
-            }
-          }
-          if (-not $vctoolsInstallDir) { throw "VCToolsInstallDir not set by vcvars64.bat" }
-          $asanBinPath = Join-Path $vctoolsInstallDir "bin\Hostx64\x64"
-          if (-not (Test-Path $asanBinPath)) { throw "MSVC ASan bin path not found: $asanBinPath" }
-          echo "asan_bin_path=$asanBinPath" >> $env:GITHUB_OUTPUT
-
-      - name: Configure (ASAN)
-        shell: bash
-        run: cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSCYCLONE_SANITIZERS=ASAN
-
-      - name: Build Test
-        shell: bash
-        run: cmake --build build --target Test --parallel
-
-      - name: Run tests
-        shell: pwsh
-        run: |
-          $env:PATH = "${{ steps.setup_msvc.outputs.asan_bin_path }};$env:PATH"
-          ctest --test-dir build -C RelWithDebInfo -L default --output-on-failure
+          title: ASan+UBSan (macOS)
+          preset: ASAN_UBSAN / asan-ubsan
+          build_dir: build-asan-ubsan
+          gate: required
+          runtime_env: ASAN_OPTIONS=abort_on_error=1 (no detect_leaks on Apple Clang)
+          outcome: ${{ job.status }}
 
   sanitize-tsan-linux:
+    name: TSan (Linux)
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
@@ -146,29 +108,33 @@ jobs:
         with:
           submodules: true
 
-      - name: Install build tools (Clang + LLVM)
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential cmake ninja-build clang llvm
+      - uses: ./.github/actions/setup-linux-juce
+        with:
+          install_clang: 'true'
 
-      - uses: ./.github/actions/juce-linux-deps
-
-      - name: Configure (THREAD - Clang)
-        env:
-          CC: clang
-          CXX: clang++
-        run: |
-          cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSCYCLONE_SANITIZERS=THREAD
+      - name: Configure (CMake preset tsan)
+        run: cmake --preset tsan
 
       - name: Build Test
-        run: cmake --build build --target Test --parallel
+        run: cmake --build --preset tsan
 
       - name: Run tests
         env:
           TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1
-        run: ctest --test-dir build -L default --output-on-failure
+        run: ctest --test-dir build-tsan -L default --output-on-failure
+
+      - uses: ./.github/actions/sanitizer-job-summary
+        if: always()
+        with:
+          title: TSan (Linux)
+          preset: THREAD / tsan
+          build_dir: build-tsan
+          gate: required
+          runtime_env: TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1
+          outcome: ${{ job.status }}
 
   sanitize-tsan-macos:
+    name: TSan (macOS)
     runs-on: macos-14
     timeout-minutes: 120
     steps:
@@ -176,178 +142,69 @@ jobs:
         with:
           submodules: true
 
-      - name: Install Ninja
-        run: brew install ninja
-
-      - name: Pin Xcode for JUCE 7 compatibility
-        uses: maxim-lobanov/setup-xcode@v1
+      - uses: ./.github/actions/setup-macos-juce
         with:
-          xcode-version: '15.4'
+          install_osxutils: 'false'
 
-      - name: Configure (THREAD - Apple Clang)
-        run: |
-          cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_OSX_ARCHITECTURES=arm64 \
-            -DSCYCLONE_SANITIZERS=THREAD
+      - name: Configure (CMake preset tsan)
+        run: cmake --preset tsan -DCMAKE_OSX_ARCHITECTURES=arm64
 
       - name: Build Test
-        run: cmake --build build --target Test --parallel
+        run: cmake --build --preset tsan
 
       - name: Run tests
         env:
           TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1
-        run: ctest --test-dir build -L default --output-on-failure
+        run: ctest --test-dir build-tsan -L default --output-on-failure
 
-  sanitize-msan-linux:
+      - uses: ./.github/actions/sanitizer-job-summary
+        if: always()
+        with:
+          title: TSan (macOS)
+          preset: THREAD / tsan
+          build_dir: build-tsan
+          gate: required
+          runtime_env: TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1
+          outcome: ${{ job.status }}
+
+  # Single job for branch protection — require this instead of four individual sanitizer jobs.
+  sanitizers-required:
+    name: sanitizers-required
+    needs:
+      - sanitize-asan-ubsan-linux
+      - sanitize-asan-ubsan-macos
+      - sanitize-tsan-linux
+      - sanitize-tsan-macos
+    if: always()
     runs-on: ubuntu-latest
-    timeout-minutes: 120
-    continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
-        with:
-          submodules: true
-
-      - name: Install build tools (Clang + Ninja for MSan libc++ build)
+      - name: Verify required sanitizer jobs
+        shell: bash
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential cmake clang llvm ninja-build python3 curl
+          check() {
+            local result="$1"
+            local name="$2"
+            if [ "$result" != "success" ]; then
+              echo "::error::Required sanitizer job '$name' finished with: $result"
+              exit 1
+            fi
+          }
+          check "${{ needs.sanitize-asan-ubsan-linux.result }}" "ASan+UBSan (Linux)"
+          check "${{ needs.sanitize-asan-ubsan-macos.result }}" "ASan+UBSan (macOS)"
+          check "${{ needs.sanitize-tsan-linux.result }}" "TSan (Linux)"
+          check "${{ needs.sanitize-tsan-macos.result }}" "TSan (macOS)"
+          echo "All required sanitizer jobs passed."
 
-      - uses: ./.github/actions/juce-linux-deps
-
-      - name: Cache MSan-instrumented libc++
-        id: msan_libcxx
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/msan-libcxx-prefix
-          key: msan-libcxx-${{ runner.os }}-${{ env.SCYCLONE_MSAN_LIBCXX_LLVM_TAG }}-v2-${{ hashFiles('.github/workflows/sanitizers.yml', 'cmake/ScycloneSanitizers.cmake') }}
-
-      - name: Build MSan-instrumented libc++/libc++abi (LLVM)
-        if: steps.msan_libcxx.outputs.cache-hit != 'true'
-        timeout-minutes: 45
+      - name: Summary
+        if: success()
         run: |
-          set -euxo pipefail
-          TAG="${SCYCLONE_MSAN_LIBCXX_LLVM_TAG}"
-          VER="${TAG#llvmorg-}"
-          curl -fsSL -o /tmp/llvm-project.tar.xz \
-            "https://github.com/llvm/llvm-project/releases/download/${TAG}/llvm-project-${VER}.src.tar.xz"
-          tar xf /tmp/llvm-project.tar.xz -C /tmp
-          SRC="/tmp/llvm-project-${VER}.src"
-          PREFIX="${GITHUB_WORKSPACE}/msan-libcxx-prefix"
-          cmake -S "${SRC}/llvm" -B /tmp/libcxx-msan-b -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
-            -DCMAKE_C_COMPILER=clang \
-            -DCMAKE_CXX_COMPILER=clang++ \
-            -DLLVM_ENABLE_PROJECTS='libcxx;libcxxabi' \
-            -DLLVM_TARGETS_TO_BUILD=X86 \
-            -DLLVM_INCLUDE_TESTS=OFF \
-            -DLLVM_INCLUDE_BENCHMARKS=OFF \
-            -DLLVM_INCLUDE_EXAMPLES=OFF \
-            -DLLVM_INCLUDE_DOCS=OFF \
-            -DLLVM_ENABLE_BINDINGS=OFF \
-            -DLLVM_ENABLE_Z3_SOLVER=OFF \
-            -DLLVM_USE_SANITIZER=Memory
-          cmake --build /tmp/libcxx-msan-b --target cxx cxxabi
-          rm -rf "${PREFIX}"
-          mkdir -p "${PREFIX}/include/c++" "${PREFIX}/lib"
-          if [ -d /tmp/libcxx-msan-b/include/c++/v1 ]; then
-            cp -a /tmp/libcxx-msan-b/include/c++/v1 "${PREFIX}/include/c++/"
-          else
-            echo "Missing generated libc++ headers under build/include/c++/v1"
-            find /tmp/libcxx-msan-b -maxdepth 4 -type d -name v1 2>/dev/null | head
-            exit 1
-          fi
-          while IFS= read -r -d '' f; do cp -P "$f" "${PREFIX}/lib/"; done < <(find /tmp/libcxx-msan-b/lib -maxdepth 3 \( -name 'libc++.so*' -o -name 'libc++abi.so*' \) -print0)
-          for f in /tmp/libcxx-msan-b/lib/libc++.a /tmp/libcxx-msan-b/lib/libc++abi.a; do
-            [ -f "$f" ] && cp -P "$f" "${PREFIX}/lib/" || true
-          done
-          compgen -G "${PREFIX}/lib/libc++.so*" >/dev/null || { echo "No libc++.so under ${PREFIX}/lib"; ls -la "${PREFIX}/lib"; exit 1; }
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          # Sanitizers — required gate
 
-      - name: Configure (MEMORY - Linux + Clang)
-        env:
-          CC: clang
-          CXX: clang++
-        run: |
-          cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSCYCLONE_SANITIZERS=MEMORY \
-            -DSCYCLONE_MSAN_LIBCXX_PREFIX="${GITHUB_WORKSPACE}/msan-libcxx-prefix"
+          ✓ ASan+UBSan (Linux) — leak authority (`detect_leaks=1`)
+          ✓ ASan+UBSan (macOS)
+          ✓ TSan (Linux)
+          ✓ TSan (macOS)
 
-      - name: Build Test
-        env:
-          LD_LIBRARY_PATH: ${{ github.workspace }}/msan-libcxx-prefix/lib:${{ env.LD_LIBRARY_PATH }}
-        run: cmake --build build --target Test --parallel
-
-      - name: Run tests
-        env:
-          MSAN_OPTIONS: halt_on_error=1
-          LD_LIBRARY_PATH: ${{ github.workspace }}/msan-libcxx-prefix/lib:${{ env.LD_LIBRARY_PATH }}
-        run: ctest --test-dir build -L default --output-on-failure
-
-  # Homebrew Clang 18 + ASan detect_leaks: experimental macOS leak probe (Apple Clang has no detect_leaks).
-  # Prebuilt ORT fails to link with Homebrew Clang — force ONNX stub. Non-blocking; see TESTING_SANITIZERS.md.
-  sanitize-asan-leaks-macos:
-    runs-on: macos-14
-    timeout-minutes: 120
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          submodules: true
-
-      - name: Cache Homebrew downloads
-        uses: actions/cache@v4
-        with:
-          path: ~/Library/Caches/Homebrew
-          key: ${{ runner.os }}-homebrew-downloads-llvm-18-${{ hashFiles('.github/workflows/sanitizers.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-homebrew-downloads-
-
-      - name: Install Homebrew LLVM 18 (for ASan + detect_leaks)
-        run: |
-          brew install llvm@18
-          LLVM_PREFIX="$(brew --prefix llvm@18)"
-          if [ ! -x "$LLVM_PREFIX/bin/clang" ]; then
-            brew reinstall llvm@18
-            LLVM_PREFIX="$(brew --prefix llvm@18)"
-          fi
-          echo "CC=$LLVM_PREFIX/bin/clang" >> "$GITHUB_ENV"
-          echo "CXX=$LLVM_PREFIX/bin/clang++" >> "$GITHUB_ENV"
-          echo "PATH=$LLVM_PREFIX/bin:$PATH" >> "$GITHUB_ENV"
-
-      - name: Install Ninja
-        run: brew install ninja
-
-      - name: Pin Xcode for JUCE 7 compatibility
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '15.4'
-
-      - name: Configure (ASAN_UBSAN — Homebrew Clang, ONNX stub auto)
-        run: |
-          cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_OSX_ARCHITECTURES=arm64 \
-            -DSCYCLONE_SANITIZERS=ASAN_UBSAN
-
-      - name: Build Test
-        run: cmake --build build --target Test --parallel
-
-      - name: Run tests (leaks warn-only)
-        id: leak_probe
-        env:
-          ASAN_OPTIONS: detect_leaks=1:abort_on_error=0
-          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=0
-          LSAN_OPTIONS: exitcode=0:print_summary=1:suppressions=${{ github.workspace }}/test/sanitizer/lsan-macos.supp
-        run: |
-          set -o pipefail
-          ctest --test-dir build -L default --output-on-failure 2>&1 | tee ctest-leak-probe.log
-          if grep -qE 'LeakSanitizer: CHECK failed|Subprocess aborted' ctest-leak-probe.log; then
-            echo "LSan internal abort detected — probe failed (see llvm/llvm-project#117476)"
-            exit 1
-          fi
-
-      - name: Upload leak probe log on failure
-        if: failure() && steps.leak_probe.outcome == 'failure'
-        uses: actions/upload-artifact@v4
-        with:
-          name: sanitize-asan-leaks-macos-log
-          path: ctest-leak-probe.log
-          retention-days: 14
+          Advisory jobs (Windows ASan, MSan, macOS leak probe) run in **Sanitizers (advisory)** workflow.
+          EOF

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -49,7 +49,8 @@ jobs:
         continue-on-error: true
         run: ./build/Test --gtest_filter=*PrintSnrMeasurements* --gtest_also_run_disabled_tests
 
-  # Apple Clang does not support detect_leaks in ASAN_OPTIONS; leak coverage is sanitize-leak-macos.
+  # Apple Clang does not support detect_leaks in ASAN_OPTIONS. Required leak gate: sanitize-asan-ubsan-linux.
+  # Experimental macOS probe: sanitize-asan-leaks-macos (Homebrew Clang + detect_leaks=1).
   sanitize-asan-ubsan-macos:
     runs-on: macos-14
     timeout-minutes: 120
@@ -281,10 +282,9 @@ jobs:
           LD_LIBRARY_PATH: ${{ github.workspace }}/msan-libcxx-prefix/lib:${{ env.LD_LIBRARY_PATH }}
         run: ctest --test-dir build -L default --output-on-failure
 
-  # Standalone LeakSan (Homebrew Clang 18): secondary macOS leak signal (Apple Clang ASan has no detect_leaks).
-  # LEAK forces ONNX stub — prebuilt ORT fails to link with Homebrew Clang (undefined GetOpSchema symbols).
-  # Job is non-blocking; LSAN_OPTIONS=exitcode=0 reports leaks without failing the test run.
-  sanitize-leak-macos:
+  # Homebrew Clang 18 + ASan detect_leaks: experimental macOS leak probe (Apple Clang has no detect_leaks).
+  # Prebuilt ORT fails to link with Homebrew Clang — force ONNX stub. Non-blocking; see TESTING_SANITIZERS.md.
+  sanitize-asan-leaks-macos:
     runs-on: macos-14
     timeout-minutes: 120
     continue-on-error: true
@@ -301,7 +301,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-homebrew-downloads-
 
-      - name: Install Homebrew LLVM 18 (for LeakSanitizer)
+      - name: Install Homebrew LLVM 18 (for ASan + detect_leaks)
         run: |
           brew install llvm@18
           LLVM_PREFIX="$(brew --prefix llvm@18)"
@@ -321,16 +321,33 @@ jobs:
         with:
           xcode-version: '15.4'
 
-      - name: Configure (LEAK - macOS with open-source Clang)
+      - name: Configure (ASAN_UBSAN — Homebrew Clang, ONNX stub auto)
         run: |
           cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_OSX_ARCHITECTURES=arm64 \
-            -DSCYCLONE_SANITIZERS=LEAK
+            -DSCYCLONE_SANITIZERS=ASAN_UBSAN
 
       - name: Build Test
         run: cmake --build build --target Test --parallel
 
       - name: Run tests (leaks warn-only)
+        id: leak_probe
         env:
-          LSAN_OPTIONS: exitcode=0:print_summary=1
-        run: ctest --test-dir build -L default --output-on-failure
+          ASAN_OPTIONS: detect_leaks=1:abort_on_error=0
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=0
+          LSAN_OPTIONS: exitcode=0:print_summary=1:suppressions=${{ github.workspace }}/test/sanitizer/lsan-macos.supp
+        run: |
+          set -o pipefail
+          ctest --test-dir build -L default --output-on-failure 2>&1 | tee ctest-leak-probe.log
+          if grep -qE 'LeakSanitizer: CHECK failed|Subprocess aborted' ctest-leak-probe.log; then
+            echo "LSan internal abort detected — probe failed (see llvm/llvm-project#117476)"
+            exit 1
+          fi
+
+      - name: Upload leak probe log on failure
+        if: failure() && steps.leak_probe.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: sanitize-asan-leaks-macos-log
+          path: ctest-leak-probe.log
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cmake --build --preset release
 
 See [test/README.md](test/README.md) for the full test layout, sanitizer presets, and calibration probes.
 
-**CI:** Pull requests to `develop` require [Build & Test](.github/workflows/build-and-test.yml) and [Sanitizers](.github/workflows/sanitizers.yml) (Linux/macOS ASan+UBSan, Linux/macOS TSan). Pushes to `develop` run the same validation (no downloadable artifacts). To release signed builds, push a version tag — see [Release process](docs/maintainer/release.md).
+**CI:** Pull requests to `develop` require [Build & Test](.github/workflows/build-and-test.yml) and [Sanitizers](.github/workflows/sanitizers.yml) (`sanitizers-required`: Linux/macOS ASan+UBSan, Linux/macOS TSan). Advisory sanitizer jobs are non-blocking — see [Sanitizers (advisory)](.github/workflows/sanitizers-advisory.yml) and [TESTING_SANITIZERS.md](docs/maintainer/TESTING_SANITIZERS.md). Pushes to `develop` run the same validation (no downloadable artifacts). To release signed builds, push a version tag — see [Release process](docs/maintainer/release.md).
 
 **Notes:**
 - The onnx library is now linked statically. No more need to download the onnx library via homebrew or via the github repository. macOS distribution builds are code-signed with Developer ID and notarized in CI.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # <img style="float: left;" src="assets/pictures/logo.png" width="40" /> &nbsp; SCYCLONE
-[![Scyclone](https://github.com/Torsion-Audio/Scyclone/actions/workflows/build_test_artifacts.yml/badge.svg)](https://github.com/Torsion-Audio/Scyclone/actions/workflows/build_test_artifacts.yml) [![Sanitizers](https://github.com/Torsion-Audio/Scyclone/actions/workflows/sanitizers.yml/badge.svg)](https://github.com/Torsion-Audio/Scyclone/actions/workflows/sanitizers.yml)
+[![Build & Test](https://github.com/Torsion-Audio/Scyclone/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/Torsion-Audio/Scyclone/actions/workflows/build-and-test.yml) [![Sanitizers](https://github.com/Torsion-Audio/Scyclone/actions/workflows/sanitizers.yml/badge.svg)](https://github.com/Torsion-Audio/Scyclone/actions/workflows/sanitizers.yml)
 ![interface](assets/pictures/interface.png)
 
 **Scyclone** is an audio plugin that utilizes **neural timbre transfer** technology to offer a new approach to audio production. The plugin builds upon [RAVE](https://github.com/acids-ircam/RAVE) methodology, a realtime audio variational auto encoder, facilitating neural timbre transfer in both single and couple inference mode. <br /><br />
@@ -58,7 +58,7 @@ cmake --build --preset release
 
 See [test/README.md](test/README.md) for the full test layout, sanitizer presets, and calibration probes.
 
-**CI:** Pushes to `develop` run validation only (no downloadable artifacts). To release signed builds, push a version tag — see [Release process](docs/maintainer/release.md).
+**CI:** Pull requests to `develop` require [Build & Test](.github/workflows/build-and-test.yml) and [Sanitizers](.github/workflows/sanitizers.yml) (Linux/macOS ASan+UBSan, Linux/macOS TSan). Pushes to `develop` run the same validation (no downloadable artifacts). To release signed builds, push a version tag — see [Release process](docs/maintainer/release.md).
 
 **Notes:**
 - The onnx library is now linked statically. No more need to download the onnx library via homebrew or via the github repository. macOS distribution builds are code-signed with Developer ID and notarized in CI.

--- a/cmake/ScycloneSanitizers.cmake
+++ b/cmake/ScycloneSanitizers.cmake
@@ -11,10 +11,20 @@ option(SCYCLONE_SANITIZER_STUB_ONNX
     "Skip linking prebuilt ONNX Runtime; compile with SCYCLONE_ONNX_STUB (MSan / MSVC ASan / LEAK)"
     OFF)
 
-# Prebuilt ONNX is not MSan-instrumented; MSVC ASan needs matching STL annotations; LEAK uses Homebrew Clang (ORT link fails).
+# Prebuilt ONNX is not MSan-instrumented; MSVC ASan needs matching STL annotations;
+# open-source Clang on macOS cannot link prebuilt ORT (Homebrew CI / LEAK preset).
+set(_scyclone_stub_onnx_required OFF)
 if(SCYCLONE_SANITIZERS STREQUAL "MEMORY"
     OR SCYCLONE_SANITIZERS STREQUAL "LEAK"
     OR (SCYCLONE_SANITIZERS STREQUAL "ASAN" AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC"))
+  set(_scyclone_stub_onnx_required ON)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin"
+    AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
+    AND (SCYCLONE_SANITIZERS STREQUAL "ASAN" OR SCYCLONE_SANITIZERS STREQUAL "ASAN_UBSAN"))
+  set(_scyclone_stub_onnx_required ON)
+endif()
+
+if(_scyclone_stub_onnx_required)
   set(SCYCLONE_SANITIZER_STUB_ONNX ON CACHE BOOL
       "Skip linking prebuilt ONNX Runtime; compile with SCYCLONE_ONNX_STUB (MSan / MSVC ASan / LEAK)" FORCE)
 else()
@@ -112,6 +122,13 @@ if(SCYCLONE_SANITIZERS STREQUAL "LEAK")
   if(_scyclone_is_gnu)
     message(FATAL_ERROR
       "LEAK (LeakSanitizer) is Clang-only. Use -DCMAKE_CXX_COMPILER=clang++.")
+  endif()
+  if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    message(WARNING
+      "Standalone LSan (SCYCLONE_SANITIZERS=LEAK) is not used in CI for GUI/JUCE tests "
+      "(llvm/llvm-project#117476). Prefer Linux ASan with ASAN_OPTIONS=detect_leaks=1, "
+      "sanitize-asan-leaks-macos in CI, or manual Xcode Instruments / leaks. "
+      "LEAK preset is retained for local experiments only.")
   endif()
 endif()
 

--- a/cmake/ScycloneSanitizers.cmake
+++ b/cmake/ScycloneSanitizers.cmake
@@ -42,7 +42,7 @@ else()
 endif()
 
 # Linux MSan: distro libc++.so is not instrumented; link against a prefix built with -fsanitize=memory
-# (see sanitize-msan-linux job in .github/workflows/sanitizers.yml).
+# (see sanitize-msan-linux job in .github/workflows/sanitizers-advisory.yml).
 set(SCYCLONE_MSAN_LIBCXX_PREFIX "" CACHE PATH
     "Install prefix of MSan-instrumented libc++/libc++abi (include/c++/v1, lib/libc++.so)")
 
@@ -182,7 +182,7 @@ else()
       else()
         message(WARNING
           "Linux MSan: SCYCLONE_MSAN_LIBCXX_PREFIX is empty; distro libc++.so is not MSan-instrumented "
-          "(false positives likely). CI builds a prefix - see sanitize-msan-linux in .github/workflows/sanitizers.yml.")
+          "(false positives likely). CI builds a prefix - see sanitize-msan-linux in .github/workflows/sanitizers-advisory.yml.")
       endif()
     endif()
     if(SCYCLONE_MSAN_TRACK_ORIGINS)

--- a/cmake/setup_tests_and_benchmarks.cmake
+++ b/cmake/setup_tests_and_benchmarks.cmake
@@ -30,8 +30,9 @@ set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
 # This command ensures that each of the named dependencies are made available to the project by the time it returns. If the dependency has already been populated the command does nothing. Otherwise, the command populates the dependency and then calls add_subdirectory() on the result.
 FetchContent_MakeAvailable(googletest)
 
-# MSan / LEAK: every object in the link must be instrumented (including FetchContent gtest).
+# MSan: every object in the link must be instrumented (including FetchContent gtest).
 # Propagate flags directly — do not link scyclone_sanitizer_flags (breaks GTest install export validation).
+# LEAK is included for harmless flag propagation; standalone LSan does not require it per Clang docs.
 if(SCYCLONE_SANITIZERS STREQUAL "MEMORY" OR SCYCLONE_SANITIZERS STREQUAL "LEAK")
     if(TARGET scyclone_sanitizer_flags)
         get_target_property(_scyclone_gt_san_compile_opts scyclone_sanitizer_flags INTERFACE_COMPILE_OPTIONS)

--- a/docs/maintainer/CI.md
+++ b/docs/maintainer/CI.md
@@ -1,0 +1,30 @@
+# CI overview — maintainers
+
+## Workflows
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| [Build & Test](../../.github/workflows/build-and-test.yml) | PR, `develop` push, `v*` tag, manual | Build + test on Linux/macOS/Windows; distribution zips on tags |
+| [Sanitizers](../../.github/workflows/sanitizers.yml) | PR, `develop` push, `v*` tag, manual | **Required** ASan+UBSan and TSan gates |
+| [Sanitizers (advisory)](../../.github/workflows/sanitizers-advisory.yml) | PR, `develop` push, `v*` tag, manual | Experimental sanitizer jobs — do not block merge |
+
+## Branch protection (PRs to `develop`)
+
+Require these check jobs:
+
+- **Build & Test** — `ci-validation` (or the workflow’s aggregate job name on your branch)
+- **Sanitizers** — `sanitizers-required` (aggregates four required sanitizer jobs)
+
+Advisory sanitizer jobs run in parallel but use `continue-on-error` and must not be required.
+
+## Shared composite actions
+
+| Action | Used for |
+|--------|----------|
+| [setup-linux-juce](../../.github/actions/setup-linux-juce/action.yml) | apt build tools + JUCE system deps |
+| [setup-macos-juce](../../.github/actions/setup-macos-juce/action.yml) | Homebrew ninja/osxutils + Xcode 15.4 pin (JUCE 7) |
+| [setup-msvc](../../.github/actions/setup-msvc/action.yml) | vswhere + vcvars64 env export |
+| [set-parallel-build-level](../../.github/actions/set-parallel-build-level/action.yml) | `CMAKE_BUILD_PARALLEL_LEVEL` from runner CPUs |
+| [sanitizer-job-summary](../../.github/actions/sanitizer-job-summary/action.yml) | `GITHUB_STEP_SUMMARY` for sanitizer jobs |
+
+Sanitizer policy and troubleshooting: [TESTING_SANITIZERS.md](TESTING_SANITIZERS.md). Release tags: [release.md](release.md).

--- a/docs/maintainer/TESTING_SANITIZERS.md
+++ b/docs/maintainer/TESTING_SANITIZERS.md
@@ -8,35 +8,62 @@ Local configure/build: [test/README.md](../../test/README.md) and [`CMakePresets
 
 | Job | Preset | Gate |
 |-----|--------|------|
-| `sanitize-asan-ubsan-linux` | `ASAN_UBSAN` | **required** |
+| `sanitize-asan-ubsan-linux` | `ASAN_UBSAN` + `detect_leaks=1` | **required** (authoritative leak gate) |
 | `sanitize-asan-ubsan-macos` | `ASAN_UBSAN` | **required** |
 | `sanitize-tsan-linux` / `sanitize-tsan-macos` | `THREAD` | **required** |
 | `sanitize-asan-msvc-windows` | `ASAN` | `continue-on-error` |
 | `sanitize-msan-linux` | `MEMORY` | `continue-on-error` |
-| `sanitize-leak-macos` | `LEAK` | `continue-on-error` |
+| `sanitize-asan-leaks-macos` | `ASAN_UBSAN` + Homebrew Clang + `detect_leaks=1` | `continue-on-error` (experimental probe) |
 
 All jobs: `ctest -L default` (see [test/README.md](../../test/README.md) for labels).
 
+## Leak detection policy
+
+**Automated (CI):** Linux `sanitize-asan-ubsan-linux` runs with `ASAN_OPTIONS=detect_leaks=1:abort_on_error=1`. This is the **required** leak gate.
+
+**macOS Apple Clang (`sanitize-asan-ubsan-macos`):** do **not** set `detect_leaks` — Apple Clang aborts with `detect_leaks is not supported on this platform`.
+
+**macOS experimental probe (`sanitize-asan-leaks-macos`):** Homebrew **`llvm@18`**, `ASAN_UBSAN`, ONNX stub (automatic for open-source `Clang` on macOS — prebuilt ORT does not link), `ASAN_OPTIONS=detect_leaks=1:abort_on_error=0`, `UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=0`, suppressions in [`test/sanitizer/lsan-macos.supp`](../../test/sanitizer/lsan-macos.supp). Non-blocking. Standalone `-fsanitize=leak` was retired — it crashed at tear-down with JUCE GUI init ([llvm#117476](https://github.com/llvm/llvm-project/issues/117476)).
+
+**Manual macOS (before release / lifetime changes):**
+
+1. Build `Test` locally (Debug or RelWithDebInfo).
+2. Run under Xcode **Instruments → Leaks**, or:
+   ```bash
+   leaks --atExit -- ./build/Test --gtest_filter=-*ExtendedHostMatrix*
+   ```
+3. Run when touching processors, ONNX thread lifetime, or JUCE-owned UI state.
+
 ## Decisions not obvious from CMake alone
 
-**Linux ASan vs macOS ASan leaks** — workflow sets `ASAN_OPTIONS=detect_leaks=1` on Linux only. Apple Clang aborts with `detect_leaks is not supported on this platform`; macOS leak signal is `sanitize-leak-macos` (Homebrew Clang, `-fsanitize=leak`, warn-only via `LSAN_OPTIONS=exitcode=0`).
+**MSan requires full link instrumentation** — every object in the link must be MSan-instrumented (including FetchContent **gtest**; see [`setup_tests_and_benchmarks.cmake`](../../cmake/setup_tests_and_benchmarks.cmake)). This does **not** apply to standalone LSan (`LEAK` preset) or to macOS `detect_leaks` via ASan.
 
-**MSan + ONNX stub** — prebuilt ORT is not MSan-instrumented. `MEMORY` forces stub ([`InferenceThreadStub.cpp`](../../source/dsp/onnx/InferenceThreadStub.cpp)); `PluginIntegrationTest` skips under `SCYCLONE_ONNX_STUB`. FetchContent **gtest** links `scyclone_sanitizer_flags` for MSan (see [`setup_tests_and_benchmarks.cmake`](../../cmake/setup_tests_and_benchmarks.cmake)).
+**MSan + ONNX stub** — prebuilt ORT is not MSan-instrumented. `MEMORY` forces stub ([`InferenceThreadStub.cpp`](../../source/dsp/onnx/InferenceThreadStub.cpp)); `PluginIntegrationTest` skips under `SCYCLONE_ONNX_STUB`.
 
-**Linux ASAN_UBSAN + PluginIntegrationTest** — prebuilt ORT + Linux UBSan hits invalid-vptr in ORT during model load; `PluginIntegrationTest` skips (`SCYCLONE_SKIP_PLUGIN_INTEGRATION_TEST`). macOS ASan still runs it.
+**Linux ASAN_UBSAN + PluginIntegrationTest** — prebuilt ORT + Linux UBSan hits invalid-vptr in ORT during model load; `PluginIntegrationTest` skips (`SCYCLONE_SKIP_PLUGIN_INTEGRATION_TEST`). macOS Apple-Clang ASan still runs it.
 
 **Windows MSVC ASan** — `ASAN` forces the same ONNX stub (LNK2038/LNK1319 without it); DSP/resampling tests run, `PluginIntegrationTest` skips.
 
-**macOS LEAK job** — pins Homebrew **`llvm@18`** (unpinned `llvm` 22 breaks JUCE 7.0.5); `-fsanitize=leak`, warn-only. `LEAK` forces ONNX stub (prebuilt ORT does not link with Homebrew Clang); DSP/resampling tests run, `PluginIntegrationTest` skips. Every static lib in the `Test` link must get the same LEAK flags as `Test` — **gtest** ([`setup_tests_and_benchmarks.cmake`](../../cmake/setup_tests_and_benchmarks.cmake)), **BinaryData** ([`assets/CMakeLists.txt`](../../assets/CMakeLists.txt)), etc. Mixed instrumentation aborts LSAN at tear-down.
+**Homebrew Clang jobs** — pin **`llvm@18`** (unpinned `llvm` 22 breaks JUCE 7.0.5). ONNX stub is **automatic** when `CMAKE_CXX_COMPILER_ID` is `Clang` (not `AppleClang`) on macOS with `ASAN` or `ASAN_UBSAN` — prebuilt ORT does not link with Homebrew Clang.
 
 **SNR floors** — Linux/macOS ASan jobs run `PrintSnrMeasurements` (`continue-on-error`) to calibrate per-OS floors in [`ResamplingSignalUtils.h`](../../test/scyclone/resampling/ResamplingSignalUtils.h). Procedure: [test/scyclone/calibration/README.md](../../test/scyclone/calibration/README.md).
+
+## macOS leak probe — evaluate after first CI run
+
+| Outcome | Action |
+|---------|--------|
+| Tests pass, clean exit, optional leak summary | Keep probe as warn-only; tune suppressions for Scyclone-only leaks |
+| `LeakSanitizer: CHECK failed` or `Subprocess aborted` at exit | Remove `sanitize-asan-leaks-macos`; rely on Linux gate + manual macOS runbook |
+| Tests pass but many `<unknown module>` leaks | Keep probe `continue-on-error`; informational only — do not gate merges |
+
+Check artifact `sanitize-asan-leaks-macos-log` on probe failure.
 
 ## When CI breaks
 
 | Symptom | Check |
 |---------|--------|
 | Linux configure / `juceaide` | [`.github/actions/juce-linux-deps`](../../.github/actions/juce-linux-deps/action.yml) ran |
-| macOS ASan aborts before tests | `detect_leaks` must not be set on macOS (see workflow) |
+| macOS Apple-Clang ASan aborts before tests | `detect_leaks` must not be set on Apple Clang jobs |
+| macOS leak probe: tests pass then `Subprocess aborted` | Known LSan + JUCE GUI/AppKit issue ([llvm#117476](https://github.com/llvm/llvm-project/issues/117476)); remove probe per table above |
 | No sanitizer in stack traces | `Test` links `scyclone_sanitizer_flags`; `-fsanitize=` in `compile_commands.json` |
-| LEAK macOS: tests pass then `Subprocess aborted` | Every `.a` in the `Test` link must be LEAK-instrumented (gtest, BinaryData, …); mixed link crashes LSAN at exit |
 | Windows tests fail after link | MSVC ASan DLL on `PATH` (CI: `VCToolsInstallDir` — see workflow Setup MSVC step) |

--- a/docs/maintainer/TESTING_SANITIZERS.md
+++ b/docs/maintainer/TESTING_SANITIZERS.md
@@ -1,29 +1,50 @@
 # Sanitizer CI — maintainers
 
-Policy and wiring for sanitizer builds. **Source of truth:** [`cmake/ScycloneSanitizers.cmake`](../../cmake/ScycloneSanitizers.cmake) (presets, flags, FATAL_ERROR rules), [`.github/workflows/sanitizers.yml`](../../.github/workflows/sanitizers.yml) (jobs, env vars, probes).
+Policy and wiring for sanitizer builds. **Build & Test workflow:** [`.github/workflows/build-and-test.yml`](../../.github/workflows/build-and-test.yml). **Source of truth:** [`cmake/ScycloneSanitizers.cmake`](../../cmake/ScycloneSanitizers.cmake) (presets, flags, FATAL_ERROR rules), [`.github/workflows/sanitizers.yml`](../../.github/workflows/sanitizers.yml) (required jobs), [`.github/workflows/sanitizers-advisory.yml`](../../.github/workflows/sanitizers-advisory.yml) (advisory jobs).
 
-Local configure/build: [test/README.md](../../test/README.md) and [`CMakePresets.json`](../../CMakePresets.json). Only **`Test`** is built/run — not plugin formats.
+Local configure/build: [test/README.md](../../test/README.md) and [`CMakePresets.json`](../../CMakePresets.json). Required CI jobs use CMake presets (`asan-ubsan`, `tsan`, `asan`). Only **`Test`** is built/run — not plugin formats.
 
 ## CI jobs
 
+### Required ([`sanitizers.yml`](../../.github/workflows/sanitizers.yml))
+
+Branch protection: require job **`sanitizers-required`** (aggregates the four jobs below).
+
 | Job | Preset | Gate |
 |-----|--------|------|
-| `sanitize-asan-ubsan-linux` | `ASAN_UBSAN` + `detect_leaks=1` | **required** (authoritative leak gate) |
-| `sanitize-asan-ubsan-macos` | `ASAN_UBSAN` | **required** |
-| `sanitize-tsan-linux` / `sanitize-tsan-macos` | `THREAD` | **required** |
-| `sanitize-asan-msvc-windows` | `ASAN` | `continue-on-error` |
-| `sanitize-msan-linux` | `MEMORY` | `continue-on-error` |
-| `sanitize-asan-leaks-macos` | `ASAN_UBSAN` + Homebrew Clang + `detect_leaks=1` | `continue-on-error` (experimental probe) |
+| `ASan+UBSan (Linux)` | `asan-ubsan` + `detect_leaks=1` | **required** (authoritative leak gate) |
+| `ASan+UBSan (macOS)` | `asan-ubsan` | **required** |
+| `TSan (Linux)` / `TSan (macOS)` | `tsan` | **required** |
+
+### Advisory ([`sanitizers-advisory.yml`](../../.github/workflows/sanitizers-advisory.yml))
+
+All jobs use `continue-on-error: true` — **do not block merge**.
+
+| Job | Preset | Gate |
+|-----|--------|------|
+| `[advisory] ASan (Windows MSVC)` | `asan` | advisory |
+| `[advisory] MSan (Linux)` | `MEMORY` (raw cmake, `build-msan`) | advisory |
+| `[advisory] ASan leaks probe (macOS)` | `ASAN_UBSAN` + Homebrew Clang + `detect_leaks=1` | advisory (experimental probe) |
 
 All jobs: `ctest -L default` (see [test/README.md](../../test/README.md) for labels).
 
+## Advisory → required promotion criteria
+
+Before moving an advisory job into `sanitizers.yml` and requiring it in branch protection:
+
+| Job | Promote when |
+|-----|----------------|
+| Windows MSVC ASan | ≥ 14 consecutive green runs; no flaky ONNX-stub skips masking regressions |
+| Linux MSan | Stable libc++ cache; tests pass without false positives from distro libs |
+| macOS leak probe | Clean exit without `LeakSanitizer: CHECK failed` / `Subprocess aborted` ([llvm#117476](https://github.com/llvm/llvm-project/issues/117476)); suppressions tuned for Scyclone-only leaks |
+
 ## Leak detection policy
 
-**Automated (CI):** Linux `sanitize-asan-ubsan-linux` runs with `ASAN_OPTIONS=detect_leaks=1:abort_on_error=1`. This is the **required** leak gate.
+**Automated (CI):** Linux `ASan+UBSan (Linux)` runs with `ASAN_OPTIONS=detect_leaks=1:abort_on_error=1`. This is the **required** leak gate.
 
-**macOS Apple Clang (`sanitize-asan-ubsan-macos`):** do **not** set `detect_leaks` — Apple Clang aborts with `detect_leaks is not supported on this platform`.
+**macOS Apple Clang (`ASan+UBSan (macOS)`):** do **not** set `detect_leaks` — Apple Clang aborts with `detect_leaks is not supported on this platform`.
 
-**macOS experimental probe (`sanitize-asan-leaks-macos`):** Homebrew **`llvm@18`**, `ASAN_UBSAN`, ONNX stub (automatic for open-source `Clang` on macOS — prebuilt ORT does not link), `ASAN_OPTIONS=detect_leaks=1:abort_on_error=0`, `UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=0`, suppressions in [`test/sanitizer/lsan-macos.supp`](../../test/sanitizer/lsan-macos.supp). Non-blocking. Standalone `-fsanitize=leak` was retired — it crashed at tear-down with JUCE GUI init ([llvm#117476](https://github.com/llvm/llvm-project/issues/117476)).
+**macOS experimental probe (`[advisory] ASan leaks probe (macOS)`):** Homebrew **`llvm@18`**, `ASAN_UBSAN`, ONNX stub (automatic for open-source `Clang` on macOS — prebuilt ORT does not link), `ASAN_OPTIONS=detect_leaks=1:abort_on_error=0`, `UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=0`, suppressions in [`test/sanitizer/lsan-macos.supp`](../../test/sanitizer/lsan-macos.supp). Non-blocking. Standalone `-fsanitize=leak` was retired — it crashed at tear-down with JUCE GUI init ([llvm#117476](https://github.com/llvm/llvm-project/issues/117476)).
 
 **Manual macOS (before release / lifetime changes):**
 
@@ -53,8 +74,8 @@ All jobs: `ctest -L default` (see [test/README.md](../../test/README.md) for lab
 | Outcome | Action |
 |---------|--------|
 | Tests pass, clean exit, optional leak summary | Keep probe as warn-only; tune suppressions for Scyclone-only leaks |
-| `LeakSanitizer: CHECK failed` or `Subprocess aborted` at exit | Remove `sanitize-asan-leaks-macos`; rely on Linux gate + manual macOS runbook |
-| Tests pass but many `<unknown module>` leaks | Keep probe `continue-on-error`; informational only — do not gate merges |
+| `LeakSanitizer: CHECK failed` or `Subprocess aborted` at exit | Remove `[advisory] ASan leaks probe (macOS)`; rely on Linux gate + manual macOS runbook |
+| Tests pass but many `<unknown module>` leaks | Keep advisory; informational only — do not gate merges |
 
 Check artifact `sanitize-asan-leaks-macos-log` on probe failure.
 
@@ -62,8 +83,8 @@ Check artifact `sanitize-asan-leaks-macos-log` on probe failure.
 
 | Symptom | Check |
 |---------|--------|
-| Linux configure / `juceaide` | [`.github/actions/juce-linux-deps`](../../.github/actions/juce-linux-deps/action.yml) ran |
+| Linux configure / `juceaide` | [`.github/actions/setup-linux-juce`](../../.github/actions/setup-linux-juce/action.yml) ran |
 | macOS Apple-Clang ASan aborts before tests | `detect_leaks` must not be set on Apple Clang jobs |
 | macOS leak probe: tests pass then `Subprocess aborted` | Known LSan + JUCE GUI/AppKit issue ([llvm#117476](https://github.com/llvm/llvm-project/issues/117476)); remove probe per table above |
 | No sanitizer in stack traces | `Test` links `scyclone_sanitizer_flags`; `-fsanitize=` in `compile_commands.json` |
-| Windows tests fail after link | MSVC ASan DLL on `PATH` (CI: `VCToolsInstallDir` — see workflow Setup MSVC step) |
+| Windows tests fail after link | MSVC ASan DLL on `PATH` (CI: [`.github/actions/setup-msvc`](../../.github/actions/setup-msvc/action.yml) with `export_asan_path`) |

--- a/docs/maintainer/release.md
+++ b/docs/maintainer/release.md
@@ -26,7 +26,7 @@ Use this for test builds or sharing zips without cutting an official release.
 
 **Signed zips only (no GitHub Release)**
 
-1. Go to **Actions → [Scyclone](https://github.com/Torsion-Audio/Scyclone/actions/workflows/build_test_artifacts.yml) → Run workflow**.
+1. Go to **Actions → [Build & Test](https://github.com/Torsion-Audio/Scyclone/actions/workflows/build-and-test.yml) → Run workflow**.
 2. Choose branch (usually `develop`), `distribution_type` (`arm64` or `universal` on macOS).
 3. Leave **create_release** off.
 4. Download zips from that run’s **Artifacts** tab (kept ~90 days). Names look like `Scyclone-macOS-universal-manual.zip`.
@@ -42,7 +42,7 @@ Same workflow, but enable **create_release** and set **release_version** to `X.Y
 | --------------------- | ------------------------------------------------------------------------------------------------ |
 | Official release zips | [GitHub → Releases](https://github.com/Torsion-Audio/Scyclone/releases)                          |
 | Manual / test zips    | Actions run → Artifacts                                                                          |
-| Workflow definition   | `[.github/workflows/build_test_artifacts.yml](../../.github/workflows/build_test_artifacts.yml)` |
+| Workflow definition   | `[.github/workflows/build-and-test.yml](../../.github/workflows/build-and-test.yml)` |
 | Pre-tag checks        | `[.github/scripts/prepare-release.sh](../../.github/scripts/prepare-release.sh)`                 |
 
 

--- a/test/README.md
+++ b/test/README.md
@@ -231,22 +231,30 @@ cmake --build --preset test
 cmake --preset release
 cmake --build --preset release
 
-# Linux/macOS sanitizer (after configure)
+# Linux/macOS sanitizer (matches CI — use runtime env vars on Linux for leak detection)
 cmake --preset asan-ubsan
 cmake --build --preset asan-ubsan
+# Linux only:
+#   export ASAN_OPTIONS=detect_leaks=1:abort_on_error=1
+#   export UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1
+# macOS Apple Clang: omit detect_leaks from ASAN_OPTIONS
 ctest --test-dir build-asan-ubsan -L default --output-on-failure
 
-# Windows sanitizer
+# Windows sanitizer (advisory in CI)
 cmake --preset asan
 cmake --build --preset asan
 ctest --test-dir build-asan -L default --output-on-failure
 ```
 
-MSan and extra sanitizer presets are not wired in CMakePresets.json (extra toolchain setup). See maintainer doc below.
+MSan and the macOS Homebrew leak probe are not in CMakePresets.json — see [docs/maintainer/TESTING_SANITIZERS.md](../docs/maintainer/TESTING_SANITIZERS.md).
 
 ## Sanitizer CI
 
-AddressSanitizer, UndefinedBehaviorSanitizer, and ThreadSanitizer run on every push/PR to `develop` via [`.github/workflows/sanitizers.yml`](../.github/workflows/sanitizers.yml). Maintainer details: [docs/maintainer/TESTING_SANITIZERS.md](../docs/maintainer/TESTING_SANITIZERS.md).
+Required gates (ASan+UBSan Linux/macOS, TSan Linux/macOS) run on every PR/push to `develop` and on `v*` tags via [`.github/workflows/sanitizers.yml`](../.github/workflows/sanitizers.yml) — require job **`sanitizers-required`** in branch protection.
+
+Advisory jobs (Windows ASan, Linux MSan, macOS leak probe) run in [`.github/workflows/sanitizers-advisory.yml`](../.github/workflows/sanitizers-advisory.yml) and do not block merge.
+
+Also see: [docs/maintainer/TESTING_SANITIZERS.md](../docs/maintainer/TESTING_SANITIZERS.md).
 
 ## IDE / IntelliSense
 

--- a/test/sanitizer/lsan-macos.supp
+++ b/test/sanitizer/lsan-macos.supp
@@ -1,0 +1,9 @@
+# LeakSanitizer suppressions for macOS system-library false positives.
+# See: https://github.com/llvm/llvm-project/issues/115992
+# Used by sanitize-asan-leaks-macos in .github/workflows/sanitizers.yml
+
+leak:_fetchInitializingClassList
+leak:dyld4::RuntimeState::_instantiateTLVs
+leak:libobjc.A.dylib
+leak:libxpc.dylib
+leak:libSystem.B.dylib


### PR DESCRIPTION
## Summary

- **Build & Test workflow** - Renamed to `build-and-test.yml`; runs on PRs. Setup deduplicated into composite actions (`setup-linux-juce`, `setup-macos-juce`, `setup-msvc`, `set-parallel-build-level`).
- **Sanitizer CI split** - Required gates in `sanitizers.yml` with `sanitizers-required` aggregator. Advisory jobs (Windows ASan, Linux MSan, macOS leak probe) in `sanitizers-advisory.yml` with `continue-on-error`.
- **Sanitizer build fixes** - Auto-stub ONNX on macOS Clang; experimental Homebrew Clang leak probe replaces standalone LEAK sanitizer.
- **Docs** — `docs/maintainer/CI.md` plus updates to sanitizer and test READMEs.

## Branch protection (post-merge)

Require **`sanitizers-required`** (not individual sanitizer jobs). Do not require advisory workflow jobs.

## Test plan

- [x] Build & Test green on Linux, macOS, Windows
- [x] `sanitizers-required` passes
- [ ] Advisory workflow runs but does not block merge
- [x] Maintainer docs reviewed